### PR TITLE
Add tab top border colour

### DIFF
--- a/react/components/molecules/tabs/tabs.js
+++ b/react/components/molecules/tabs/tabs.js
@@ -55,6 +55,8 @@ export class Tabs extends PureComponent {
 const styles = StyleSheet.create({
     root: {
         paddingTop: 0,
+        borderTopColor: "#e4e8f0",
+        borderTopWidth: 1,
         backgroundColor: "#ffffff",
         flexDirection: "row"
     }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | There was no top border color in the container of the tab component |
| Decisions | Add tab top border colour  |
| Animated GIF | ![Feb-18-2020 16-45-38](https://user-images.githubusercontent.com/13239857/74757623-2b9fe200-526e-11ea-8fd5-d69a3b82eaf3.gif) |
