### PR TITLE
Fix header back button

### DIFF
--- a/react/components/molecules/header/header.js
+++ b/react/components/molecules/header/header.js
@@ -106,11 +106,13 @@ const styles = StyleSheet.create({
         textAlign: "center"
     },
     containerButtonLeft: {
+        zIndex: 1,
         position: "absolute",
         top: 18,
         left: 10
     },
     containerButtonRight: {
+        zIndex: 1,
         position: "absolute",
         top: 18,
         right: 10

--- a/react/components/molecules/header/header.js
+++ b/react/components/molecules/header/header.js
@@ -41,7 +41,8 @@ export class Header extends PureComponent {
         };
     }
 
-    goBack = () => this.props.navigation &&  this.props.navigation.canGoBack() && this.props.navigation.pop(1);
+    goBack = () =>
+        this.props.navigation && this.props.navigation.canGoBack() && this.props.navigation.pop(1);
 
     render() {
         return (

--- a/react/components/molecules/header/header.js
+++ b/react/components/molecules/header/header.js
@@ -41,7 +41,7 @@ export class Header extends PureComponent {
         };
     }
 
-    goBack = () => this.props.navigation && this.props.navigation.pop(1);
+    goBack = () => this.props.navigation &&  this.props.navigation.canGoBack() && this.props.navigation.pop(1);
 
     render() {
         return (


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | The back button doesn't work, this happens because the button was behind the box of the title. |
| Decisions | Apply the zIndex to style so the button can go to the top of the title to receive touch events  |
| Animated GIF |Before: ![image](https://user-images.githubusercontent.com/13239857/75173399-b6795480-5726-11ea-8442-71a6f756d3ca.png) After:![image (1)](https://user-images.githubusercontent.com/13239857/75173406-b8dbae80-5726-11ea-8fb4-738d97453e37.png)   |
