### PR TITLE
TextArea component padding fix

### DIFF
--- a/react/components/atoms/textarea/textarea.js
+++ b/react/components/atoms/textarea/textarea.js
@@ -71,6 +71,7 @@ export class TextArea extends PureComponent {
 
 const styles = StyleSheet.create({
     textArea: {
+        paddingVertical: 0,
         paddingLeft: 15,
         paddingRight: 15,
         color: "#3e566a"


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | - |
| Decisions | Fixed `TextArea` vertical padding being different in Android |
| Animated GIF | ![RN-TextArea_padding_fix](https://user-images.githubusercontent.com/22588915/75981644-d6560880-5edc-11ea-9b0a-53631f16b80b.gif) |
