### PR TITLE
Fix box-shadow/elevation of Item in Android

### DIFF
--- a/react/components/molecules/item/item.js
+++ b/react/components/molecules/item/item.js
@@ -113,6 +113,7 @@ const styles = StyleSheet.create({
             width: 0,
             height: 2
         },
+        elevation: 2,
         shadowRadius: 2,
         shadowColor: "#435664",
         shadowOpacity: 0.2


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Missing box shadow in item component in Android. Example: <img width="466" alt="Screenshot 2020-03-05 at 12 20 47" src="https://user-images.githubusercontent.com/25725586/75982210-f2a67500-5edd-11ea-9adc-6f558ff8255f.png">|
| Decisions | Added elevation, similar to button-keyboard. |
| Animated GIF | <img width="466" alt="Screenshot 2020-03-05 at 12 20 54" src="https://user-images.githubusercontent.com/25725586/75982228-fd610a00-5edd-11ea-8647-5b2056085318.png">|
