### PR TITLE
Fix keyboard alignment

### DIFF
--- a/react/components/atoms/button-keyboard/button-keyboard.js
+++ b/react/components/atoms/button-keyboard/button-keyboard.js
@@ -14,7 +14,8 @@ export class ButtonKeyboard extends PureComponent {
             text: PropTypes.string,
             value: PropTypes.any,
             variant: PropTypes.string,
-            onPress: PropTypes.func
+            onPress: PropTypes.func,
+            style: PropTypes.object
         };
     }
 
@@ -25,6 +26,7 @@ export class ButtonKeyboard extends PureComponent {
             text: undefined,
             value: undefined,
             variant: undefined,
+            style: {},
             onPress: () => {}
         };
     }
@@ -34,7 +36,7 @@ export class ButtonKeyboard extends PureComponent {
     };
 
     _style = () => {
-        const base = [styles.buttonKeyboard];
+        const base = [styles.buttonKeyboard, this.props.style];
         switch (this.props.variant) {
             case "clean":
                 base.push(styles.cleanStyle);
@@ -65,7 +67,6 @@ const styles = StyleSheet.create({
     buttonKeyboard: {
         flex: 1,
         maxHeight: 54,
-        marginHorizontal: 2,
         alignItems: "center",
         justifyContent: "center",
         backgroundColor: "#ffffff",

--- a/react/components/atoms/button-keyboard/button-keyboard.js
+++ b/react/components/atoms/button-keyboard/button-keyboard.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import { StyleSheet, Text, TouchableOpacity, Platform, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 
-import { baseStyles } from "../../../util";
+import { baseStyles, capitalize } from "../../../util";
 
 import { Icon } from "../icon";
 
@@ -36,15 +36,11 @@ export class ButtonKeyboard extends PureComponent {
     };
 
     _style = () => {
-        const base = [styles.buttonKeyboard, this.props.style];
-        switch (this.props.variant) {
-            case "clean":
-                base.push(styles.cleanStyle);
-                break;
-            default:
-                break;
-        }
-        return base;
+        return [
+            styles.buttonKeyboard,
+            styles[`buttonKeyboard${capitalize(this.props.variant)}`],
+            this.props.style
+        ];
     };
 
     render() {
@@ -79,7 +75,7 @@ const styles = StyleSheet.create({
             height: 3
         }
     },
-    cleanStyle: {
+    buttonKeyboardClean: {
         backgroundColor: "transparent",
         elevation: 0,
         shadowOpacity: 0

--- a/react/components/atoms/button-keyboard/button-keyboard.js
+++ b/react/components/atoms/button-keyboard/button-keyboard.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from "react";
-import { StyleSheet, Text, TouchableOpacity, Platform } from "react-native";
+import { StyleSheet, Text, TouchableOpacity, Platform, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 
 import { baseStyles } from "../../../util";
@@ -15,7 +15,7 @@ export class ButtonKeyboard extends PureComponent {
             value: PropTypes.any,
             variant: PropTypes.string,
             onPress: PropTypes.func,
-            style: PropTypes.object
+            style: ViewPropTypes.style
         };
     }
 

--- a/react/components/molecules/keyboard-numeric/keyboard-numeric.js
+++ b/react/components/molecules/keyboard-numeric/keyboard-numeric.js
@@ -65,7 +65,8 @@ const styles = StyleSheet.create({
         marginBottom: 5
     },
     filler: {
-        flex: 1
+        flex: 1,
+        marginHorizontal: 2
     }
 });
 

--- a/react/components/molecules/keyboard-numeric/keyboard-numeric.js
+++ b/react/components/molecules/keyboard-numeric/keyboard-numeric.js
@@ -21,24 +21,75 @@ export class KeyboardNumeric extends PureComponent {
         return (
             <View style={styles.keyboardNumeric}>
                 <View style={styles.row}>
-                    <ButtonKeyboard text={"1"} value={1} onPress={this.props.onKeyPress} />
-                    <ButtonKeyboard text={"2"} value={2} onPress={this.props.onKeyPress} />
-                    <ButtonKeyboard text={"3"} value={3} onPress={this.props.onKeyPress} />
-                </View>
-                <View style={styles.row}>
-                    <ButtonKeyboard text={"4"} value={4} onPress={this.props.onKeyPress} />
-                    <ButtonKeyboard text={"5"} value={5} onPress={this.props.onKeyPress} />
-                    <ButtonKeyboard text={"6"} value={6} onPress={this.props.onKeyPress} />
-                </View>
-                <View style={styles.row}>
-                    <ButtonKeyboard text={"7"} value={7} onPress={this.props.onKeyPress} />
-                    <ButtonKeyboard text={"8"} value={8} onPress={this.props.onKeyPress} />
-                    <ButtonKeyboard text={"9"} value={9} onPress={this.props.onKeyPress} />
-                </View>
-                <View style={styles.row}>
-                    <View style={styles.filler} />
-                    <ButtonKeyboard text={"0"} value={0} onPress={this.props.onKeyPress} />
                     <ButtonKeyboard
+                        style={styles.buttonKeyboard}
+                        text={"1"}
+                        value={1}
+                        onPress={this.props.onKeyPress}
+                    />
+                    <ButtonKeyboard
+                        style={styles.buttonKeyboard}
+                        text={"2"}
+                        value={2}
+                        onPress={this.props.onKeyPress}
+                    />
+                    <ButtonKeyboard
+                        style={styles.buttonKeyboard}
+                        text={"3"}
+                        value={3}
+                        onPress={this.props.onKeyPress}
+                    />
+                </View>
+                <View style={styles.row}>
+                    <ButtonKeyboard
+                        style={styles.buttonKeyboard}
+                        text={"4"}
+                        value={4}
+                        onPress={this.props.onKeyPress}
+                    />
+                    <ButtonKeyboard
+                        style={styles.buttonKeyboard}
+                        text={"5"}
+                        value={5}
+                        onPress={this.props.onKeyPress}
+                    />
+                    <ButtonKeyboard
+                        style={styles.buttonKeyboard}
+                        text={"6"}
+                        value={6}
+                        onPress={this.props.onKeyPress}
+                    />
+                </View>
+                <View style={styles.row}>
+                    <ButtonKeyboard
+                        style={styles.buttonKeyboard}
+                        text={"7"}
+                        value={7}
+                        onPress={this.props.onKeyPress}
+                    />
+                    <ButtonKeyboard
+                        style={styles.buttonKeyboard}
+                        text={"8"}
+                        value={8}
+                        onPress={this.props.onKeyPress}
+                    />
+                    <ButtonKeyboard
+                        style={styles.buttonKeyboard}
+                        text={"9"}
+                        value={9}
+                        onPress={this.props.onKeyPress}
+                    />
+                </View>
+                <View style={styles.row}>
+                    <View style={[styles.filler, styles.buttonKeyboard]} />
+                    <ButtonKeyboard
+                        style={styles.buttonKeyboard}
+                        text={"0"}
+                        value={0}
+                        onPress={this.props.onKeyPress}
+                    />
+                    <ButtonKeyboard
+                        style={styles.buttonKeyboard}
                         icon="chevron-left"
                         variant={"clean"}
                         value={"delete"}
@@ -64,9 +115,11 @@ const styles = StyleSheet.create({
         flexDirection: "row",
         marginBottom: 5
     },
-    filler: {
-        flex: 1,
+    buttonKeyboard: {
         marginHorizontal: 2
+    },
+    filler: {
+        flex: 1
     }
 });
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Keyboard button `0` was not aligned with the rest of the buttons: NOTE: The red is temporary, only for the buttons to be noticeable. <img width="466" alt="Screenshot 2020-03-05 at 12 20 54" src="https://user-images.githubusercontent.com/25725586/75983663-d1935380-5ee0-11ea-96b9-abffe5399bc8.png"> <img width="467" alt="Screenshot 2020-03-05 at 12 55 09" src="https://user-images.githubusercontent.com/25725586/75983676-d952f800-5ee0-11ea-98bb-d126b4762b7b.png"> |
| Decisions | Added marginHorizontal to filler, so that it occupies the same width as a numeric button. |
| Animated GIF | <img width="460" alt="Screenshot 2020-03-05 at 12 54 57" src="https://user-images.githubusercontent.com/25725586/75983712-ecfe5e80-5ee0-11ea-99da-46803e8b0a7f.png"> |
