### PR TITLE
Fix add image list camera authorization error handler func

### DIFF
--- a/react/util/ui-utils.js
+++ b/react/util/ui-utils.js
@@ -1,4 +1,4 @@
-import { Alert } from "react-native";
+import { Alert, Linking, Platform } from "react-native";
 import DocumentPicker from "react-native-document-picker";
 import ImagePicker from "react-native-image-picker";
 
@@ -22,6 +22,18 @@ export const pickDocuments = async function(options = {}) {
             throw err;
         }
     }
+};
+
+const authorizeCamera = function() {
+    Alert.alert(
+        "Authorize camera access in settings",
+        null,
+        [
+            { text: "Not now" },
+            { text: "Settings", onPress: () => Linking.openURL("app-settings:") }
+        ],
+        { cancelable: false }
+    );
 };
 
 const normalizeImage = function(image) {
@@ -57,7 +69,9 @@ export const pickImage = async function(options) {
             }
 
             if (response.error) {
-                Alert.alert("Error", "Could not load image", { cancelable: false });
+                Platform.OS === "ios" && response.error === "Camera permissions not granted"
+                    ? authorizeCamera()
+                    : Alert.alert("Error", "Could not load image", { cancelable: false });
                 reject(new Error({ reason: "error", message: response.error }));
                 return;
             }

--- a/react/util/ui-utils.js
+++ b/react/util/ui-utils.js
@@ -24,18 +24,6 @@ export const pickDocuments = async function(options = {}) {
     }
 };
 
-const authorizeCamera = function() {
-    Alert.alert(
-        "Authorize camera access in settings",
-        null,
-        [
-            { text: "Not now" },
-            { text: "Settings", onPress: () => Linking.openURL("app-settings:") }
-        ],
-        { cancelable: false }
-    );
-};
-
 const normalizeImage = function(image) {
     return {
         uri: image.uri,
@@ -69,9 +57,20 @@ export const pickImage = async function(options) {
             }
 
             if (response.error) {
-                Platform.OS === "ios" && response.error === "Camera permissions not granted"
-                    ? authorizeCamera()
-                    : Alert.alert("Error", "Could not load image", { cancelable: false });
+                if (Platform.OS === "ios" && response.error === "Camera permissions not granted") {
+                    Alert.alert(
+                        "Authorize camera access in settings",
+                        null,
+                        [
+                            { text: "Not now" },
+                            { text: "Settings", onPress: () => Linking.openURL("app-settings:") }
+                        ],
+                        { cancelable: false }
+                    );
+                } else {
+                    Alert.alert("Error", "Could not load image", { cancelable: false });
+                }
+
                 reject(new Error({ reason: "error", message: response.error }));
                 return;
             }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | When camera is not authorized and in `image-list` component we click to "Add photo" and select "Take photo...", a warning of rejected promise is thrown and the user is not notified that he needs to give camera permissions in settings.  |
| Environment | This is only reproducible for **iOS**. In Android the OS takes care of letting the user know that he needs to give the right permissions and Android already shows it's own dialog for this. |
| Decisions | - |
| Animated GIF |  ![IMG_F1C3E3801513-1](https://user-images.githubusercontent.com/24736423/76312608-51e3fb00-62cb-11ea-9dcc-48c0631c045f.jpeg) |
