### PR TITLE
Fix item's headerDate

### DIFF
--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -51,7 +51,6 @@ export class TabsText extends PureComponent {
     _updateBar = () => {
         const index = this.state.tabSelected;
         const tabLayout = this.tabLayouts[index];
-
         if (tabLayout) {
             this.setState({ animatedBarOffset: tabLayout.x, animatedBarWidth: tabLayout.width });
         } else {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Currently the prop `headerDate`is not being applied. This PR fixes this and formats the timestamp using `dateTimeString` from utils |
| Decisions |   |
| Animated GIF | <img width="410" alt="imagem" src="https://user-images.githubusercontent.com/24736423/76610461-d96e7b80-6510-11ea-9657-f8ba95ae388f.png"> |
