### PR TITLE
Fix item's headerDate

### DIFF
--- a/react/components/molecules/item/item.js
+++ b/react/components/molecules/item/item.js
@@ -4,7 +4,7 @@ import LinearGradient from "react-native-linear-gradient";
 
 import PropTypes from "prop-types";
 
-import { capitalize } from "../../../util";
+import { capitalize, dateTimeString } from "../../../util";
 
 import { Icon, Text } from "../../atoms";
 
@@ -78,7 +78,9 @@ export class Item extends PureComponent {
                                         {this.props.headerText}
                                     </Text>
                                 </View>
-                                <Text style={styles.headerText}>{this.dateData}</Text>
+                                <Text style={styles.headerText}>
+                                    {dateTimeString(this.props.headerDate)}
+                                </Text>
                             </View>
                         </LinearGradient>
                     )}


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Currently the prop `headerDate`is not being applied. This PR fixes this and formats the timestamp using `dateTimeString` from utils |
| Decisions |   |
| Animated GIF | <img width="410" alt="imagem" src="https://user-images.githubusercontent.com/24736423/76610461-d96e7b80-6510-11ea-9657-f8ba95ae388f.png"> |
