### PR TITLE
Fix text not breaking when space is short, and as result would overfl…

### DIFF
--- a/react/components/molecules/item-notification/item-notification.js
+++ b/react/components/molecules/item-notification/item-notification.js
@@ -62,7 +62,6 @@ const styles = StyleSheet.create({
         borderBottomColor: "#e4e8f0",
         borderBottomWidth: 2,
         flexDirection: "row",
-        height: 86,
         justifyContent: "center",
         paddingBottom: 15,
         paddingLeft: 14,
@@ -72,12 +71,12 @@ const styles = StyleSheet.create({
     text: {
         flex: 1,
         fontSize: 16,
-        paddingLeft: 14
+        marginLeft: 14
     },
     timestamp: {
         color: "#a8b3bb",
         fontSize: 14,
-        textAlign: "center",
+        textAlign: "right",
         maxWidth: 80
     }
 });

--- a/react/components/molecules/item-notification/item-notification.js
+++ b/react/components/molecules/item-notification/item-notification.js
@@ -70,14 +70,14 @@ const styles = StyleSheet.create({
         paddingRight: 20
     },
     text: {
+        flex: 1,
         fontSize: 16,
         paddingLeft: 14
     },
     timestamp: {
         color: "#a8b3bb",
         fontSize: 14,
-        right: 0,
         textAlign: "center",
-        width: 65
+        maxWidth: 80
     }
 });


### PR DESCRIPTION


| - | - |
| --- | --- |
| Issue | Text is not breaking on reach is max width, and it makes the other components to overflow |
| Decisions | Set `flex:1` to the text component so it knows it's width limits and breaks on the correct place.  | 
| Animated GIF | Before the fix ![Simulator Screen Shot - iPhone 11 - 2020-03-13 at 11 00 50](https://user-images.githubusercontent.com/13239857/76615422-ee9bd800-6519-11ea-9ee4-97d3a45bf917.png) After the fix ![Simulator Screen Shot - iPhone 11 - 2020-03-13 at 11 00 31](https://user-images.githubusercontent.com/13239857/76615447-f8254000-6519-11ea-9a96-548d49612764.png)  |
