### PR TITLE
ContainerDraggable dragging opacity fix

### DIFF
--- a/react/components/atoms/container-draggable/container-draggable.js
+++ b/react/components/atoms/container-draggable/container-draggable.js
@@ -46,6 +46,7 @@ export class ContainerDraggable extends PureComponent {
         this.contentHeightPercentage = this.opening ? -1 * movePercentage : 1 - movePercentage;
         this.contentHeightPercentage = Math.min(1, Math.max(this.contentHeightPercentage, 0));
 
+        this.child.setOverlayVisible(this.dragging);
         this.child.setOverlayOpacity(0.5 * this.contentHeightPercentage);
         this.child.setContentHeight(this.contentHeightPercentage);
     };
@@ -57,6 +58,7 @@ export class ContainerDraggable extends PureComponent {
         }
 
         this.dragging = false;
+        this.child.setOverlayVisible(this.dragging);
 
         if (this.contentHeightPercentage > this.props.snapCloseThreshold) {
             this.child.open();


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | - |
| Dependencies | https://github.com/ripe-tech/ripe-components-react-native/pull/114 |
| Decisions | Fixed overlay not showing when the container was being dragged up |
| Animated GIF | **Without the fix:**<br>![RN-ContainerDraggable_overlay_opacity_without_fix](https://user-images.githubusercontent.com/22588915/77196333-073c5d00-6adb-11ea-9067-7679c492d74c.gif) <br>**With the fix:**<br>![RN-ContainerDraggable_overlay_opacity_fix](https://user-images.githubusercontent.com/22588915/77196332-05729980-6adb-11ea-948d-23e8258ba377.gif) |
