### PR TITLE
ContainerDraggable storybook story toggle button fix

### DIFF
--- a/react/components/atoms/container-draggable/container-draggable.stories.js
+++ b/react/components/atoms/container-draggable/container-draggable.stories.js
@@ -23,7 +23,7 @@ storiesOf("Atoms", module)
                 <Button
                     title="Toggle Container"
                     onPress={() => {
-                        ref.current.toggle();
+                        ref.current.child.toggle();
                     }}
                 />
                 <View style={styles.otherContent}>
@@ -52,8 +52,9 @@ storiesOf("Atoms", module)
                 <ContainerDraggable
                     pressThreshold={pressThreshold}
                     snapCloseThreshold={snapCloseThreshold}
+                    ref={ref}
                 >
-                    <ContainerOpenable modal={modal} header={customHeader} ref={ref}>
+                    <ContainerOpenable modal={modal} header={customHeader}>
                         <Text style={styles.content}>
                             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
                             tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | - |
| Dependencies | https://github.com/ripe-tech/ripe-components-react-native/pull/114 |
| Decisions | Fixed the reference error when trying to use the toggle button in the `ContainerDraggable` storybook story |
| Animated GIF | - |
