### PR TITLE
#120 TabsText variant support

### DIFF
--- a/react/components/atoms/button-tab-text/button-tab-text.js
+++ b/react/components/atoms/button-tab-text/button-tab-text.js
@@ -72,14 +72,14 @@ const styles = StyleSheet.create({
         alignItems: "center"
     },
     buttonTabTextCompact: {
-        paddingVertical: 9
+        paddingVertical: 9,
+        paddingHorizontal: 16
     },
     text: {
         marginTop: Platform.OS === "ios" ? 4 : 0,
         fontFamily: baseStyles.FONT,
         fontSize: 16,
-        letterSpacing: 0.25,
-        textAlign: "center"
+        letterSpacing: 0.25
     },
     textCompact: {
         fontSize: 14,

--- a/react/components/atoms/button-tab-text/button-tab-text.js
+++ b/react/components/atoms/button-tab-text/button-tab-text.js
@@ -83,7 +83,7 @@ const styles = StyleSheet.create({
     },
     textCompact: {
         marginTop: 0,
-        fontFamily: baseStyles.FONT_BOLD,
+        fontFamily: baseStyles.FONT_BOOK,
         fontSize: 14
     },
     textDisabled: {

--- a/react/components/atoms/button-tab-text/button-tab-text.js
+++ b/react/components/atoms/button-tab-text/button-tab-text.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import { StyleSheet, Platform, TouchableOpacity, Text } from "react-native";
 import PropTypes from "prop-types";
 
-import { baseStyles } from "../../../util";
+import { baseStyles, capitalize } from "../../../util";
 
 export class ButtonTabText extends PureComponent {
     static get propTypes() {
@@ -12,6 +12,7 @@ export class ButtonTabText extends PureComponent {
             color: PropTypes.string,
             text: PropTypes.string,
             disabled: PropTypes.bool,
+            variant: PropTypes.string,
             onPress: PropTypes.func
         };
     }
@@ -23,6 +24,7 @@ export class ButtonTabText extends PureComponent {
             color: "#162633",
             text: undefined,
             disabled: false,
+            variant: undefined,
             onPress: undefined
         };
     }
@@ -30,6 +32,7 @@ export class ButtonTabText extends PureComponent {
     _style() {
         return [
             styles.buttonTabText,
+            styles[`buttonTabText${capitalize(this.props.variant)}`],
             { backgroundColor: this.props.backgroundColor },
             this.props.style
         ];
@@ -38,6 +41,7 @@ export class ButtonTabText extends PureComponent {
     _styleText() {
         return [
             styles.text,
+            styles[`text${capitalize(this.props.variant)}`],
             {
                 color: this.props.color
             },
@@ -65,12 +69,19 @@ const styles = StyleSheet.create({
         paddingHorizontal: 4,
         alignItems: "center"
     },
+    buttonTabTextCompact: {
+        paddingVertical: 9
+    },
     text: {
         marginTop: Platform.OS === "ios" ? 4 : 0,
         fontFamily: baseStyles.FONT,
         fontSize: 16,
         letterSpacing: 0.25,
         textAlign: "center"
+    },
+    textCompact: {
+        fontSize: 14,
+        marginTop: 0
     },
     textDisabled: {
         opacity: 0.4

--- a/react/components/atoms/button-tab-text/button-tab-text.js
+++ b/react/components/atoms/button-tab-text/button-tab-text.js
@@ -82,8 +82,9 @@ const styles = StyleSheet.create({
         letterSpacing: 0.25
     },
     textCompact: {
-        fontSize: 14,
-        marginTop: 0
+        marginTop: 0,
+        fontFamily: baseStyles.FONT_BOLD,
+        fontSize: 14
     },
     textDisabled: {
         opacity: 0.4

--- a/react/components/atoms/button-tab-text/button-tab-text.js
+++ b/react/components/atoms/button-tab-text/button-tab-text.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from "react";
-import { StyleSheet, Platform, TouchableOpacity, Text } from "react-native";
+import { ViewPropTypes, StyleSheet, Platform, TouchableOpacity, Text } from "react-native";
 import PropTypes from "prop-types";
 
 import { baseStyles, capitalize } from "../../../util";
@@ -13,7 +13,8 @@ export class ButtonTabText extends PureComponent {
             text: PropTypes.string,
             disabled: PropTypes.bool,
             variant: PropTypes.string,
-            onPress: PropTypes.func
+            onPress: PropTypes.func,
+            style: ViewPropTypes.style
         };
     }
 
@@ -25,7 +26,8 @@ export class ButtonTabText extends PureComponent {
             text: undefined,
             disabled: false,
             variant: undefined,
-            onPress: undefined
+            onPress: undefined,
+            style: {}
         };
     }
 

--- a/react/components/atoms/button-tab-text/button-tab-text.stories.js
+++ b/react/components/atoms/button-tab-text/button-tab-text.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react-native";
-import { withKnobs, text, boolean } from "@storybook/addon-knobs";
+import { withKnobs, text, boolean, select } from "@storybook/addon-knobs";
 
 import { ButtonTabText } from "./button-tab-text";
 
@@ -11,12 +11,21 @@ storiesOf("Atoms", module)
         const backgroundColor = text("Background Color", null);
         const disabled = boolean("Disabled", false);
         const active = boolean("Active", true);
+        const variant = select(
+            "Variant",
+            {
+                Unset: undefined,
+                Compact: "compact"
+            },
+            undefined
+        );
         return (
             <ButtonTabText
                 active={active}
                 text={_text || undefined}
                 disabled={disabled}
                 backgroundColor={backgroundColor}
+                variant={variant}
                 onPress={() => alert("Thanks for the press!")}
             />
         );

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -87,12 +87,16 @@ export class TabsText extends PureComponent {
         ];
     }
 
+    _buttonStyle = () => {
+        return this.props.variant === undefined && styles.button;
+    }
+
     _renderTabs() {
         return this.props.tabs.map((tab, index) => (
             <View
+                style={this._buttonStyle()}
                 key={tab.text}
                 onLayout={event => this._onTabLayout(event, index)}
-                style={styles.button}
             >
                 <ButtonTabText
                     text={tab.text}
@@ -125,11 +129,11 @@ const styles = StyleSheet.create({
     tabsText: {
         borderBottomWidth: 1,
         borderBottomColor: "#e4e8f0",
-        flexDirection: "row",
-        position: "relative"
+        flexDirection: "row"
     },
     tabsTextCompact: {
-        borderBottomWidth: 0
+        borderBottomWidth: 0,
+        backgroundColor: "#f6f7f9"
     },
     button: {
         flex: 1

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -16,6 +16,7 @@ export class TabsText extends PureComponent {
                 }).isRequired
             ).isRequired,
             tabSelected: PropTypes.number,
+            variant: PropTypes.string,
             style: ViewPropTypes.style
         };
     }
@@ -25,6 +26,7 @@ export class TabsText extends PureComponent {
             hasAnimation: true,
             tabs: [],
             tabSelected: 0,
+            variant: undefined,
             style: {}
         };
     }

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -5,18 +5,6 @@ import PropTypes from "prop-types";
 import { ButtonTabText, BarAnimated } from "../../atoms";
 
 export class TabsText extends PureComponent {
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            tabs: props.tabs,
-            tabSelected: props.tabSelected,
-            animatedBarWidth: undefined,
-            animatedBarOffset: undefined
-        };
-        this.tabLayouts = {};
-    }
-
     static get propTypes() {
         return {
             onTabChange: PropTypes.func.isRequired,
@@ -39,6 +27,18 @@ export class TabsText extends PureComponent {
             tabSelected: 0,
             style: {}
         };
+    }
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            tabs: props.tabs,
+            tabSelected: props.tabSelected,
+            animatedBarWidth: undefined,
+            animatedBarOffset: undefined
+        };
+        this.tabLayouts = {};
     }
 
     onTabPress = tabSelectedIndex => {

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -89,7 +89,7 @@ export class TabsText extends PureComponent {
 
     _buttonStyle = () => {
         return this.props.variant === undefined && styles.button;
-    }
+    };
 
     _renderTabs() {
         return this.props.tabs.map((tab, index) => (
@@ -100,6 +100,7 @@ export class TabsText extends PureComponent {
             >
                 <ButtonTabText
                     text={tab.text}
+                    color={"#24425a"}
                     onPress={() => this.onTabPress(index)}
                     active={this.state.tabSelected === index}
                     disabled={tab.disabled}

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -2,6 +2,8 @@ import React, { PureComponent } from "react";
 import { StyleSheet, ViewPropTypes, View } from "react-native";
 import PropTypes from "prop-types";
 
+import { capitalize } from "../../../util";
+
 import { ButtonTabText, BarAnimated } from "../../atoms";
 
 export class TabsText extends PureComponent {
@@ -65,7 +67,8 @@ export class TabsText extends PureComponent {
         Boolean(
             this.props.hasAnimation &&
                 this.state.animatedBarWidth !== undefined &&
-                this.state.animatedBarOffset !== undefined
+                this.state.animatedBarOffset !== undefined &&
+                this.props.variant === undefined
         );
 
     _onTabLayout = (event, index) => {
@@ -77,7 +80,11 @@ export class TabsText extends PureComponent {
     };
 
     _style() {
-        return [styles.tabsText, this.props.style];
+        return [
+            styles.tabsText,
+            styles[`tabsText${capitalize(this.props.variant)}`],
+            this.props.style
+        ];
     }
 
     _renderTabs() {
@@ -92,6 +99,7 @@ export class TabsText extends PureComponent {
                     onPress={() => this.onTabPress(index)}
                     active={this.state.tabSelected === index}
                     disabled={tab.disabled}
+                    variant={this.props.variant}
                 />
             </View>
         ));
@@ -119,6 +127,9 @@ const styles = StyleSheet.create({
         borderBottomColor: "#e4e8f0",
         flexDirection: "row",
         position: "relative"
+    },
+    tabsTextCompact: {
+        borderBottomWidth: 0
     },
     button: {
         flex: 1

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -88,7 +88,7 @@ export class TabsText extends PureComponent {
     }
 
     _buttonStyle = () => {
-        return this.props.variant === undefined && styles.button;
+        return [styles.button, styles[`button${capitalize(this.props.variant)}`]];
     };
 
     _renderTabs() {
@@ -138,6 +138,9 @@ const styles = StyleSheet.create({
     },
     button: {
         flex: 1
+    },
+    buttonCompact: {
+        flex: 0
     },
     barAnimated: {
         position: "absolute",

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -7,7 +7,6 @@ import { ButtonTabText, BarAnimated } from "../../atoms";
 export class TabsText extends PureComponent {
     static get propTypes() {
         return {
-            onTabChange: PropTypes.func.isRequired,
             hasAnimation: PropTypes.bool,
             tabs: PropTypes.arrayOf(
                 PropTypes.shape({
@@ -17,6 +16,7 @@ export class TabsText extends PureComponent {
             ).isRequired,
             tabSelected: PropTypes.number,
             variant: PropTypes.string,
+            onTabChange: PropTypes.func.isRequired,
             style: ViewPropTypes.style
         };
     }

--- a/react/components/molecules/tabs-text/tabs-text.stories.js
+++ b/react/components/molecules/tabs-text/tabs-text.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react-native";
-import { withKnobs } from "@storybook/addon-knobs";
+import { withKnobs, select } from "@storybook/addon-knobs";
 
 import { TabsText } from "./tabs-text";
 
@@ -14,8 +14,16 @@ storiesOf("Molecules", module)
             { text: "New", disabled: false },
             { text: "Past", disabled: true }
         ];
+        const variant = select(
+            "Variant",
+            {
+                Unset: undefined,
+                Compact: "compact"
+            },
+            undefined
+        );
 
         const onTabChange = tabIndex => alert(`Switched to index: ${tabIndex}`);
 
-        return <TabsText tabs={tabs} tabSelected={0} onTabChange={onTabChange} />;
+        return <TabsText tabs={tabs} tabSelected={0} variant={variant} onTabChange={onTabChange} />;
     });


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-components-react-native/issues/120 |
| Decisions | • Added variant prop to `TabsText` and `ButtonTabText` components <br>• `TabsText` and `ButtonTabText` components now support `compact` variant <br>• Fixed missing `style` prop in `ButtonTabText` component |
| Animated GIF | ![RN-TabsText_variant_compact](https://user-images.githubusercontent.com/22588915/77445852-81275b80-6de5-11ea-9cb1-9635dec8b9dd.gif) |
