### PR TITLE
#72 Added support for the remount of the container in the ContainerOpenable component

### DIFF
--- a/react/components/atoms/container-openable/container-openable.js
+++ b/react/components/atoms/container-openable/container-openable.js
@@ -159,21 +159,25 @@ export class ContainerOpenable extends PureComponent {
     _onContainerLayout = event => {
         if (this.state.containerHeightLoaded) return;
 
-        if (this.remountingContainer && this.containerHeight > 0) {
-            this.setContentHeight(this.containerHeight / event.nativeEvent.layout.height);
-            Animated.timing(this.state.contentHeight, {
-                toValue: 1,
-                duration: this.props.animationsDuration,
-                easing: Easing.inOut(Easing.ease)
-            }).start(() => {
-                this.remountingContainer = false;
-            });
-        }
+        const previousHeight = this.containerHeight;
 
         this.containerHeight = event.nativeEvent.layout.height;
         this.containerPosY = event.nativeEvent.layout.y + this.containerHeight;
 
-        this.setState({ containerHeightLoaded: true });
+        this.setState({ containerHeightLoaded: true }, () => {
+            if (this.remountingContainer && previousHeight > 0) {
+                this.animating = true;
+                this.setContentHeight(previousHeight / this.containerHeight);
+                Animated.timing(this.state.contentHeight, {
+                    toValue: 1,
+                    duration: this.props.animationsDuration,
+                    easing: Easing.inOut(Easing.ease)
+                }).start(() => {
+                    this.animating = false;
+                    this.remountingContainer = false;
+                });
+            }
+        });
     };
 
     _onHeaderLayout = event => {

--- a/react/components/atoms/container-openable/container-openable.js
+++ b/react/components/atoms/container-openable/container-openable.js
@@ -168,11 +168,20 @@ export class ContainerOpenable extends PureComponent {
             if (this.remountingContainer && previousHeight > 0) {
                 this.animating = true;
                 this.setContentHeight(previousHeight / this.containerHeight);
-                Animated.timing(this.state.contentHeight, {
-                    toValue: 1,
-                    duration: this.props.animationsDuration,
-                    easing: Easing.inOut(Easing.ease)
-                }).start(() => {
+
+                Animated.parallel([
+                    Animated.timing(this.state.contentHeight, {
+                        toValue: 1,
+                        duration: this.props.animationsDuration,
+                        easing: Easing.inOut(Easing.ease)
+                    }),
+                    Animated.timing(this.state.overlayOpacity, {
+                        toValue: 0.5,
+                        duration: this.props.animationsDuration,
+                        useNativeDriver: true,
+                        easing: Easing.inOut(Easing.ease)
+                    })
+                ]).start(() => {
                     this.animating = false;
                     this.remountingContainer = false;
                 });


### PR DESCRIPTION

| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/72 |
| Dependencies | -- |
| Decisions | The `remountContainer()` method makes the component recalculate the container height and animates from the previous height to the new height |
| Animated GIF | -- |
