### PR TITLE
#149 ButtonIcon component with native feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-components-react-native",
-    "version": "0.2.9",
+    "version": "0.2.10",
     "description": "RIPE Components for React Native",
     "keywords": [
         "components",

--- a/react/components/atoms/button-icon/button-icon.js
+++ b/react/components/atoms/button-icon/button-icon.js
@@ -3,12 +3,14 @@ import { StyleSheet, ViewPropTypes, TouchableOpacity } from "react-native";
 import PropTypes from "prop-types";
 
 import { Icon } from "../icon";
+import { Touchable } from "../touchable";
 
 export class ButtonIcon extends PureComponent {
     static get propTypes() {
         return {
             icon: PropTypes.string.isRequired,
             size: PropTypes.number.isRequired,
+            nativeFeedback: PropTypes.bool,
             backgroundColor: PropTypes.string,
             iconFill: PropTypes.string,
             iconHeight: PropTypes.number,
@@ -30,6 +32,7 @@ export class ButtonIcon extends PureComponent {
         return {
             size: 30,
             backgroundColor: "#ffffff",
+            nativeFeedback: false,
             iconFill: undefined,
             iconHeight: 20,
             iconWidth: 20,
@@ -53,7 +56,8 @@ export class ButtonIcon extends PureComponent {
                 borderRadius: this.props.size / 2,
                 backgroundColor: this.props.backgroundColor,
                 width: this.props.size,
-                height: this.props.size
+                height: this.props.size,
+                overflow: this.props.nativeFeedback ? "hidden" : undefined
             },
             this.props.style
         ];
@@ -61,20 +65,39 @@ export class ButtonIcon extends PureComponent {
 
     render() {
         return (
-            <TouchableOpacity
-                onPress={this.props.onPress}
-                disabled={!this.props.onPress}
-                style={this._style()}
-            >
-                <Icon
-                    icon={this.props.icon}
-                    color={this.props.iconStrokeColor}
-                    fill={this.props.iconFill}
-                    width={this.props.iconWidth}
-                    height={this.props.iconHeight}
-                    strokeWidth={this.props.iconStrokeWidth}
-                />
-            </TouchableOpacity>
+            <>
+                {this.props.nativeFeedback ? (
+                    <Touchable
+                        onPress={this.props.onPress}
+                        disabled={!this.props.onPress}
+                        style={this._style()}
+                    >
+                        <Icon
+                            icon={this.props.icon}
+                            color={this.props.iconStrokeColor}
+                            fill={this.props.iconFill}
+                            width={this.props.iconWidth}
+                            height={this.props.iconHeight}
+                            strokeWidth={this.props.iconStrokeWidth}
+                        />
+                    </Touchable>
+                ) : (
+                    <TouchableOpacity
+                        onPress={this.props.onPress}
+                        disabled={!this.props.onPress}
+                        style={this._style()}
+                    >
+                        <Icon
+                            icon={this.props.icon}
+                            color={this.props.iconStrokeColor}
+                            fill={this.props.iconFill}
+                            width={this.props.iconWidth}
+                            height={this.props.iconHeight}
+                            strokeWidth={this.props.iconStrokeWidth}
+                        />
+                    </TouchableOpacity>
+                )}
+            </>
         );
     }
 }

--- a/react/components/atoms/button-icon/button-icon.stories.js
+++ b/react/components/atoms/button-icon/button-icon.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react-native";
-import { withKnobs, number, text, select } from "@storybook/addon-knobs";
+import { withKnobs, select, number, boolean, text } from "@storybook/addon-knobs";
 
 import { ButtonIcon } from "./button-icon";
 
@@ -17,8 +17,9 @@ storiesOf("Atoms", module)
             "add"
         );
         const size = number("Size", 30);
-        const iconStrokeColor = text("Icon Stroke Color", "#ffffff");
-        const backgroundColor = text("Background Color", "#000000");
+        const useNativeFeedback = boolean("Native Feedback", false);
+        const iconStrokeColor = text("Icon Stroke Color", "#000000");
+        const backgroundColor = text("Background Color", "#e8e8e8");
         const height = number("Icon Height", 20);
         const width = number("Icon Width", 20);
         const strokeWidth = number("Icon Stroke Width", 1);
@@ -26,6 +27,7 @@ storiesOf("Atoms", module)
             <ButtonIcon
                 icon={icon}
                 size={size}
+                nativeFeedback={useNativeFeedback}
                 iconStrokeColor={iconStrokeColor}
                 backgroundColor={backgroundColor}
                 iconStrokeWidth={strokeWidth}


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/149 |
| Dependencies | https://github.com/ripe-tech/ripe-components-react-native/pull/143 |
| Decisions | • Added prop `nativeFeedback`  to `ButtonIcon` to give the option to use native feedback<br>• This option was added because the some icons don't look good when using native feedback in Android. This happens because the icons we use are not squared, some have more height/width than others so they look like they have more/less padding around them. For instance, in the `RichTextInput`component, it looks better without the native feedback.<br>**With `nativeFeedback=true`:**<br>![with_feedback](https://user-images.githubusercontent.com/22588915/80234972-ebcfef00-8650-11ea-8132-af16d627cf23.gif)<br>**With `nativeFeedback=false`:**<br>![Without_native_feedback](https://user-images.githubusercontent.com/22588915/80234982-ef637600-8650-11ea-97e1-be4ac0fd3ad0.gif) |
| Animated GIF | ![RN-ButtonIcon_native_feedback_prop](https://user-images.githubusercontent.com/22588915/79860402-836fdc00-83ca-11ea-8040-98540f9c2497.gif) |
