### PR TITLE
#155: Device detection improvement

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "peerDependencies": {
         "react": "^16.13.1",
         "react-native": "^0.61.5",
+        "react-native-device-info": "^5.5.6",
         "react-native-document-picker": "^3.3.3",
         "react-native-image-picker": "^2.3.1",
         "react-native-linear-gradient": "^2.5.6",

--- a/react/util/ui-utils.js
+++ b/react/util/ui-utils.js
@@ -1,4 +1,5 @@
 import { Alert, Dimensions, Linking, Platform, ToastAndroid } from "react-native";
+import DeviceInfo from "react-native-device-info";
 import DocumentPicker from "react-native-document-picker";
 import ImagePicker from "react-native-image-picker";
 
@@ -88,6 +89,14 @@ export const pickImage = async function (options) {
 
     const result = await promise;
     return result;
+};
+
+export const isTablet = function () {
+    return DeviceInfo.isTablet();
+};
+
+export const isMobile = function () {
+    return !isTablet();
 };
 
 export const notify = function (message) {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/155 |
| Dependencies | |
| Decisions | Using react-native-device-info to access the device info. This way it is possible to know if the device is a tablet.  |
| Animated GIF | -- |
