### PR TITLE
#160 Key Values custom columns number

### DIFF
--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -20,7 +20,7 @@ export class KeyValues extends PureComponent {
 
     static get defaultProps() {
         return {
-            columnsNr: 1,
+            columnsNr: undefined,
             style: {}
         };
     }
@@ -29,17 +29,17 @@ export class KeyValues extends PureComponent {
         super(props);
 
         this.keyValuesFiller =
-            this.props.columnsNr > 1 ? this.props.items.length % this.props.columnsNr : 0;
+            this.props.columnsNr ? this.props.items.length % this.props.columnsNr : 0;
     }
 
     width = () => `${(100 / this.props.columnsNr) * 0.96}%`;
 
     _style = () => {
-        return [this.props.columnsNr > 1 ? styles.keyValuesColumns : {}, this.props.style];
+        return [this.props.columnsNr ? styles.keyValuesColumns : {}, this.props.style];
     };
 
     _keyValueStyle = (isFiller = false) => {
-        return this.props.columnsNr > 1
+        return this.props.columnsNr
             ? {
                   width: this.width(),
                   opacity: isFiller ? 0 : 1

--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -10,7 +10,20 @@ export class KeyValues extends PureComponent {
             items: PropTypes.arrayOf(
                 PropTypes.shape({
                     key: PropTypes.string.isRequired,
-                    value: PropTypes.string.isRequired
+                    value: PropTypes.string.isRequired,
+                    keyColor: PropTypes.string,
+                    valueColor: PropTypes.string,
+                    icon: PropTypes.string,
+                    iconBackgroundColor: PropTypes.string,
+                    iconColor: PropTypes.string,
+                    iconSize: PropTypes.number,
+                    iconHeight: PropTypes.number,
+                    iconWidth: PropTypes.number,
+                    iconStrokeWidth: PropTypes.number,
+                    pressable: PropTypes.bool,
+                    onPress: PropTypes.func,
+                    onButtonIconPress: PropTypes.func,
+                    onLongPress: PropTypes.func
                 })
             ).isRequired,
             columnsNr: PropTypes.number,
@@ -83,6 +96,19 @@ export class KeyValues extends PureComponent {
                         key={item.key}
                         _key={item.key}
                         value={item.value}
+                        keyColor={item.keyColor}
+                        valueColor={item.valueColor}
+                        icon={item.icon}
+                        iconBackgroundColor={item.iconBackgroundColor}
+                        iconColor={item.iconColor}
+                        iconSize={item.iconSize}
+                        iconHeight={item.iconHeight}
+                        iconWidth={item.iconWidth}
+                        iconStrokeWidth={item.iconStrokeWidth}
+                        pressable={item.pressable}
+                        onPress={item.onPress}
+                        onButtonIconPress={item.onButtonIconPress}
+                        onLongPress={item.onLongPress}
                     >
                         {item.valueComponent}
                     </KeyValue>

--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from "react";
-import { View, ViewPropTypes } from "react-native";
+import { StyleSheet, View, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 
 import { KeyValue } from "../key-value";
@@ -13,25 +13,81 @@ export class KeyValues extends PureComponent {
                     value: PropTypes.string.isRequired
                 })
             ).isRequired,
+            columnsNr: PropTypes.number,
             style: ViewPropTypes.style
         };
     }
 
     static get defaultProps() {
-        return { style: {} };
+        return {
+            columnsNr: 1,
+            style: {}
+        };
     }
+
+    constructor(props) {
+        super(props);
+
+        this.keyValuesFiller =
+            this.props.columnsNr > 1 ? this.props.items.length % this.props.columnsNr : 0;
+    }
+
+    width = () => `${(100 / this.props.columnsNr) * 0.96}%`;
+
+    _style = () => {
+        return [this.props.columnsNr > 1 ? styles.keyValuesColumns : {}, this.props.style];
+    };
+
+    _keyValueStyle = (isFiller = false) => {
+        return this.props.columnsNr > 1
+            ? {
+                  width: this.width(),
+                  opacity: isFiller ? 0 : 1
+              }
+            : {};
+    };
+
+    _keyValuesFiller = () => {
+        const filler = [];
+
+        for (let i = 0; i < this.keyValuesFiller; i++)
+            filler.push(
+                <KeyValue
+                    style={this._keyValueStyle(true)}
+                    key={`fill-${i}`}
+                    _key={`fill-${i}`}
+                    value={""}
+                />
+            );
+
+        return filler;
+    };
 
     render() {
         return (
-            <View style={this.props.style}>
+            <View style={this._style()}>
                 {this.props.items.map(item => (
-                    <KeyValue key={item.key} _key={item.key} value={item.value}>
+                    <KeyValue
+                        style={this._keyValueStyle()}
+                        key={item.key}
+                        _key={item.key}
+                        value={item.value}
+                    >
                         {item.valueComponent}
                     </KeyValue>
                 ))}
+                {this._keyValuesFiller()}
             </View>
         );
     }
 }
+
+const styles = StyleSheet.create({
+    keyValuesColumns: {
+        flexDirection: "row",
+        flexWrap: "wrap",
+        justifyContent: "space-between"
+    }
+});
 
 export default KeyValues;

--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -3,7 +3,7 @@ import { StyleSheet, View, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 
 import { KeyValue } from "../key-value";
-import { isTabletSize } from "../../../util/ui-utils";
+import { isTabletSize } from "../../../util";
 
 export class KeyValues extends PureComponent {
     static get propTypes() {

--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -44,7 +44,7 @@ export class KeyValues extends PureComponent {
     };
 
     _keyValueWrapperStyle = () => {
-        return this.props.keyValueTwoColumns ? styles.twoColumns : {};
+        return this.props.keyValueTwoColumns ? styles.keyValueWrapperColumns : {};
     };
 
     _keyValueStyle = index => {
@@ -90,7 +90,7 @@ const styles = StyleSheet.create({
         flexWrap: "wrap",
         justifyContent: "space-between"
     },
-    twoColumns: {
+    keyValueWrapperColumns: {
         width: "50%"
     },
     keyValueColumnRight: {

--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -28,8 +28,19 @@ export class KeyValues extends PureComponent {
     constructor(props) {
         super(props);
 
-        this.keyValuesFiller =
-            this.props.columnsNr ? this.props.items.length % this.props.columnsNr : 0;
+        this.state = {
+            keyValuesFiller: this.props.columnsNr
+                ? this.props.items.length % this.props.columnsNr
+                : 0
+        };
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.columnsNr !== this.props.columnsNr) {
+            this.setState({
+                keyValuesFiller: this.props.columnsNr
+            });
+        }
     }
 
     width = () => `${(100 / this.props.columnsNr) * 0.96}%`;
@@ -50,7 +61,7 @@ export class KeyValues extends PureComponent {
     _keyValuesFiller = () => {
         const filler = [];
 
-        for (let i = 0; i < this.keyValuesFiller; i++)
+        for (let i = 0; i < this.state.keyValuesFiller; i++)
             filler.push(
                 <KeyValue
                     style={this._keyValueStyle(true)}

--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -27,28 +27,28 @@ export class KeyValues extends PureComponent {
                     onLongPress: PropTypes.func
                 })
             ).isRequired,
-            twoColumns: PropTypes.bool,
+            keyValueTwoColumns: PropTypes.bool,
             style: ViewPropTypes.style
         };
     }
 
     static get defaultProps() {
         return {
-            twoColumns: isTabletSize(),
+            keyValueTwoColumns: isTabletSize(),
             style: {}
         };
     }
 
     _style = () => {
-        return [this.props.twoColumns ? styles.keyValuesColumns : {}, this.props.style];
+        return [this.props.keyValueTwoColumns ? styles.keyValuesColumns : {}, this.props.style];
     };
 
     _keyValueWrapperStyle = () => {
-        return this.props.twoColumns ? styles.twoColumns : {};
+        return this.props.keyValueTwoColumns ? styles.twoColumns : {};
     };
 
     _keyValueStyle = index => {
-        return this.props.twoColumns && index % 2 > 0 ? styles.keyValueColumnRight : {};
+        return this.props.keyValueTwoColumns && index % 2 > 0 ? styles.keyValueColumnRight : {};
     };
 
     render() {

--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -3,6 +3,7 @@ import { StyleSheet, View, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 
 import { KeyValue } from "../key-value";
+import { isTabletSize } from "../../../util/ui-utils";
 
 export class KeyValues extends PureComponent {
     static get propTypes() {
@@ -26,65 +27,24 @@ export class KeyValues extends PureComponent {
                     onLongPress: PropTypes.func
                 })
             ).isRequired,
-            columnsNr: PropTypes.number,
+            twoColumns: PropTypes.bool,
             style: ViewPropTypes.style
         };
     }
 
     static get defaultProps() {
         return {
-            columnsNr: undefined,
+            twoColumns: isTabletSize(),
             style: {}
         };
     }
 
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            keyValuesFiller: this.props.columnsNr
-                ? this.props.items.length % this.props.columnsNr
-                : 0
-        };
-    }
-
-    componentDidUpdate(prevProps) {
-        if (prevProps.columnsNr !== this.props.columnsNr) {
-            this.setState({
-                keyValuesFiller: this.props.columnsNr
-            });
-        }
-    }
-
-    width = () => `${(100 / this.props.columnsNr) * 0.96}%`;
-
     _style = () => {
-        return [this.props.columnsNr ? styles.keyValuesColumns : {}, this.props.style];
+        return [this.props.twoColumns ? styles.keyValuesColumns : {}, this.props.style];
     };
 
-    _keyValueStyle = (isFiller = false) => {
-        return this.props.columnsNr
-            ? {
-                  width: this.width(),
-                  opacity: isFiller ? 0 : 1
-              }
-            : {};
-    };
-
-    _keyValuesFiller = () => {
-        const filler = [];
-
-        for (let i = 0; i < this.state.keyValuesFiller; i++)
-            filler.push(
-                <KeyValue
-                    style={this._keyValueStyle(true)}
-                    key={`fill-${i}`}
-                    _key={`fill-${i}`}
-                    value={""}
-                />
-            );
-
-        return filler;
+    _keyValueStyle = () => {
+        return this.props.twoColumns ? styles.keyValueTwoColumns : {};
     };
 
     render() {
@@ -113,7 +73,6 @@ export class KeyValues extends PureComponent {
                         {item.valueComponent}
                     </KeyValue>
                 ))}
-                {this._keyValuesFiller()}
             </View>
         );
     }
@@ -124,6 +83,9 @@ const styles = StyleSheet.create({
         flexDirection: "row",
         flexWrap: "wrap",
         justifyContent: "space-between"
+    },
+    keyValueTwoColumns: {
+        width: "48%"
     }
 });
 

--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -43,35 +43,41 @@ export class KeyValues extends PureComponent {
         return [this.props.twoColumns ? styles.keyValuesColumns : {}, this.props.style];
     };
 
-    _keyValueStyle = () => {
-        return this.props.twoColumns ? styles.keyValueTwoColumns : {};
+    _keyValueWrapperStyle = () => {
+        return this.props.twoColumns ? styles.twoColumns : {};
+    };
+
+    _keyValueStyle = index => {
+        return this.props.twoColumns && index % 2 > 0 ? styles.keyValueTwoColumns : {};
     };
 
     render() {
         return (
             <View style={this._style()}>
-                {this.props.items.map(item => (
-                    <KeyValue
-                        style={this._keyValueStyle()}
-                        key={item.key}
-                        _key={item.key}
-                        value={item.value}
-                        keyColor={item.keyColor}
-                        valueColor={item.valueColor}
-                        icon={item.icon}
-                        iconBackgroundColor={item.iconBackgroundColor}
-                        iconColor={item.iconColor}
-                        iconSize={item.iconSize}
-                        iconHeight={item.iconHeight}
-                        iconWidth={item.iconWidth}
-                        iconStrokeWidth={item.iconStrokeWidth}
-                        pressable={item.pressable}
-                        onPress={item.onPress}
-                        onButtonIconPress={item.onButtonIconPress}
-                        onLongPress={item.onLongPress}
-                    >
-                        {item.valueComponent}
-                    </KeyValue>
+                {this.props.items.map((item, index) => (
+                    <View style={this._keyValueWrapperStyle()}>
+                        <KeyValue
+                            style={this._keyValueStyle(index)}
+                            key={item.key}
+                            _key={item.key}
+                            value={item.value}
+                            keyColor={item.keyColor}
+                            valueColor={item.valueColor}
+                            icon={item.icon}
+                            iconBackgroundColor={item.iconBackgroundColor}
+                            iconColor={item.iconColor}
+                            iconSize={item.iconSize}
+                            iconHeight={item.iconHeight}
+                            iconWidth={item.iconWidth}
+                            iconStrokeWidth={item.iconStrokeWidth}
+                            pressable={item.pressable}
+                            onPress={item.onPress}
+                            onButtonIconPress={item.onButtonIconPress}
+                            onLongPress={item.onLongPress}
+                        >
+                            {item.valueComponent}
+                        </KeyValue>
+                    </View>
                 ))}
             </View>
         );
@@ -84,8 +90,11 @@ const styles = StyleSheet.create({
         flexWrap: "wrap",
         justifyContent: "space-between"
     },
+    twoColumns: {
+        width: "50%"
+    },
     keyValueTwoColumns: {
-        width: "48%"
+        marginLeft: 40
     }
 });
 

--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -48,7 +48,7 @@ export class KeyValues extends PureComponent {
     };
 
     _keyValueStyle = index => {
-        return this.props.twoColumns && index % 2 > 0 ? styles.keyValueTwoColumns : {};
+        return this.props.twoColumns && index % 2 > 0 ? styles.keyValueColumnRight : {};
     };
 
     render() {
@@ -93,7 +93,7 @@ const styles = StyleSheet.create({
     twoColumns: {
         width: "50%"
     },
-    keyValueTwoColumns: {
+    keyValueColumnRight: {
         marginLeft: 40
     }
 });

--- a/react/components/molecules/key-values/key-values.stories.js
+++ b/react/components/molecules/key-values/key-values.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react-native";
-import { withKnobs } from "@storybook/addon-knobs";
+import { withKnobs, number } from "@storybook/addon-knobs";
 
 import { KeyValues } from "./key-values";
 
@@ -14,5 +14,7 @@ storiesOf("Molecules", module)
             { key: "Birth date", value: "14/03/1993" },
             { key: "Nationality", value: "Portuguese" }
         ];
-        return <KeyValues items={items} />;
+        const columnsNr = number("Number of Columns", 1);
+
+        return <KeyValues items={items} columnsNr={columnsNr} />;
     });

--- a/react/components/molecules/key-values/key-values.stories.js
+++ b/react/components/molecules/key-values/key-values.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react-native";
-import { withKnobs, number } from "@storybook/addon-knobs";
+import { withKnobs, boolean } from "@storybook/addon-knobs";
 
 import { KeyValues } from "./key-values";
 
@@ -14,7 +14,7 @@ storiesOf("Molecules", module)
             { key: "Birth date", value: "14/03/1993" },
             { key: "Nationality", value: "Portuguese" }
         ];
-        const columnsNr = number("Number of Columns", 1);
+        const twoColumns = boolean("Two Columns", false);
 
-        return <KeyValues items={items} columnsNr={columnsNr} />;
+        return <KeyValues items={items} twoColumns={twoColumns} />;
     });


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/160 |
| Dependencies | -- |
| Decisions | • Added the optinal boolean prop `twoColumns` to make `KeyValues` have two columns. In tablet it defaults too true <br>• Supports all of the `KeyValue` props |
| Animated GIF | **Two Columns in tablet:**<br>![RN-Key_values_only_two_columns](https://user-images.githubusercontent.com/22588915/80712980-a72dd300-8aea-11ea-9baf-644eda783a68.gif)<br>**The addition of all the KeyValue props, allowed to have pressable columns as an example:**<br>![RN-Key_values_support_for_more_props](https://user-images.githubusercontent.com/22588915/80711189-d98a0100-8ae7-11ea-8750-5e73576fb2a1.gif) |
