### PR TITLE
#150 - Added button to close the light box

### DIFF
--- a/react/components/atoms/lightbox/lightbox.js
+++ b/react/components/atoms/lightbox/lightbox.js
@@ -3,6 +3,7 @@ import { ViewPropTypes, StyleSheet, View, Image, Modal } from "react-native";
 import PropTypes from "prop-types";
 
 import { Touchable } from "../touchable";
+import { ButtonIcon } from "../button-icon";
 
 export class Lightbox extends PureComponent {
     static get propTypes() {
@@ -49,8 +50,16 @@ export class Lightbox extends PureComponent {
         );
     }
 
-    onBackButtonPress = () => {
+    closeLigthBox() {
         this.setVisibility(false);
+    }
+
+    onBackButtonPress = () => {
+        this.closeLigthBox();
+    };
+
+    onClosePress = () => {
+        this.closeLigthBox();
     };
 
     onLightboxPress = () => {
@@ -96,6 +105,17 @@ export class Lightbox extends PureComponent {
                 >
                     <View style={styles.fullscreenContainer}>
                         <Image style={this._imageFullscreenStyle()} source={this._imageSource()} />
+                        <ButtonIcon
+                            icon={"close"}
+                            onPress={this.onClosePress}
+                            style={styles.buttonClose}
+                            iconStrokeWidth={2}
+                            size={34}
+                            iconHeight={22}
+                            iconWidth={22}
+                            backgroundColor={"rgba(0,0,0,0.6)"}
+                            iconStrokeColor={"#ffffff"}
+                        />
                     </View>
                 </Modal>
             </View>
@@ -114,6 +134,11 @@ const styles = StyleSheet.create({
     fullscreenContainer: {
         flex: 1,
         backgroundColor: "#000000"
+    },
+    buttonClose: {
+        position: "absolute",
+        top: "6%",
+        left: "4%"
     }
 });
 

--- a/react/components/atoms/lightbox/lightbox.js
+++ b/react/components/atoms/lightbox/lightbox.js
@@ -2,6 +2,8 @@ import React, { PureComponent } from "react";
 import { ViewPropTypes, StyleSheet, View, Image, Modal } from "react-native";
 import PropTypes from "prop-types";
 
+import { isTabletSize } from "../../../util";
+
 import { Touchable } from "../touchable";
 import { ButtonIcon } from "../button-icon";
 
@@ -110,10 +112,10 @@ export class Lightbox extends PureComponent {
                             onPress={this.onClosePress}
                             style={styles.buttonClose}
                             iconStrokeWidth={2}
-                            size={34}
-                            iconHeight={22}
-                            iconWidth={22}
-                            backgroundColor={"rgba(0,0,0,0.6)"}
+                            size={isTabletSize() ? 52 : 34}
+                            iconHeight={isTabletSize() ? 34 : 22}
+                            iconWidth={isTabletSize() ? 34 : 22}
+                            backgroundColor={"#000000"}
                             iconStrokeColor={"#ffffff"}
                         />
                     </View>


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-components-react-native/issues/150 |
| Dependencies | - |
| Decisions | The Lightbox component didn't had a button to close it once you had opened the component on iOS. Now we added a new button that will allow the users to use it to close the Lightbox. |
| Animated GIF | ![May-14-2020 14-47-47](https://user-images.githubusercontent.com/13239857/81942901-a3be3f80-95f2-11ea-9fad-476d6e0a6ddd.gif) |
