### PR TITLE
Add test IDs

### DIFF
--- a/react/components/atoms/avatar/avatar.js
+++ b/react/components/atoms/avatar/avatar.js
@@ -21,8 +21,7 @@ export class Avatar extends PureComponent {
                 bottom: PropTypes.number.isRequired
             }),
             onPress: PropTypes.func,
-            style: ViewPropTypes.style,
-            testId: PropTypes.string
+            style: ViewPropTypes.style
         };
     }
 
@@ -34,8 +33,7 @@ export class Avatar extends PureComponent {
             resizeMode: "contain",
             hitSlop: { top: 20, left: 20, right: 20, bottom: 20 },
             onPress: undefined,
-            style: {},
-            testId: undefined
+            style: {}
         };
     }
 
@@ -64,7 +62,7 @@ export class Avatar extends PureComponent {
                     source={this.props.image}
                     style={styles.image}
                     resizeMode={this.props.resizeMode}
-                    {...(this.props.testId ? genTestProps(this.props.testId) : {})}
+                    {...genTestProps("avatar", this.testSuffix)}
                 />
             </Touchable>
         );

--- a/react/components/atoms/avatar/avatar.js
+++ b/react/components/atoms/avatar/avatar.js
@@ -2,6 +2,8 @@ import React, { PureComponent } from "react";
 import { ViewPropTypes, StyleSheet, Image } from "react-native";
 import PropTypes from "prop-types";
 
+import { testId } from "../../../util";
+
 import { Touchable } from "../touchable";
 
 export class Avatar extends PureComponent {
@@ -18,8 +20,9 @@ export class Avatar extends PureComponent {
                 right: PropTypes.number.isRequired,
                 bottom: PropTypes.number.isRequired
             }),
+            onPress: PropTypes.func,
             style: ViewPropTypes.style,
-            onPress: PropTypes.func
+            testId: PropTypes.string
         };
     }
 
@@ -30,8 +33,9 @@ export class Avatar extends PureComponent {
             borderRadius: 100,
             resizeMode: "contain",
             hitSlop: { top: 20, left: 20, right: 20, bottom: 20 },
+            onPress: undefined,
             style: {},
-            onPress: undefined
+            testId: undefined
         };
     }
 
@@ -60,6 +64,7 @@ export class Avatar extends PureComponent {
                     source={this.props.image}
                     style={styles.image}
                     resizeMode={this.props.resizeMode}
+                    {...this.props.testId ? testId(this.props.testId) : {}}
                 />
             </Touchable>
         );

--- a/react/components/atoms/avatar/avatar.js
+++ b/react/components/atoms/avatar/avatar.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import { ViewPropTypes, StyleSheet, Image } from "react-native";
 import PropTypes from "prop-types";
 
-import { testId } from "../../../util";
+import { genTestProps } from "../../../util";
 
 import { Touchable } from "../touchable";
 
@@ -64,7 +64,7 @@ export class Avatar extends PureComponent {
                     source={this.props.image}
                     style={styles.image}
                     resizeMode={this.props.resizeMode}
-                    {...(this.props.testId ? testId(this.props.testId) : {})}
+                    {...(this.props.testId ? genTestProps(this.props.testId) : {})}
                 />
             </Touchable>
         );

--- a/react/components/atoms/avatar/avatar.js
+++ b/react/components/atoms/avatar/avatar.js
@@ -62,7 +62,7 @@ export class Avatar extends PureComponent {
                     source={this.props.image}
                     style={styles.image}
                     resizeMode={this.props.resizeMode}
-                    {...genTestProps("avatar", this.testSuffix)}
+                    {...genTestProps(this.props.testPrefix, "avatar")}
                 />
             </Touchable>
         );

--- a/react/components/atoms/avatar/avatar.js
+++ b/react/components/atoms/avatar/avatar.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import { ViewPropTypes, StyleSheet, Image } from "react-native";
 import PropTypes from "prop-types";
 
-import { genTestProps } from "../../../util";
+import { genIdProps } from "../../../util";
 
 import { Touchable } from "../touchable";
 
@@ -62,7 +62,7 @@ export class Avatar extends PureComponent {
                     source={this.props.image}
                     style={styles.image}
                     resizeMode={this.props.resizeMode}
-                    {...genTestProps(this.props.testPrefix, "avatar")}
+                    {...genIdProps(this.props.idPrefix, "avatar")}
                 />
             </Touchable>
         );

--- a/react/components/atoms/avatar/avatar.js
+++ b/react/components/atoms/avatar/avatar.js
@@ -1,12 +1,13 @@
 import React, { PureComponent } from "react";
 import { ViewPropTypes, StyleSheet, Image } from "react-native";
 import PropTypes from "prop-types";
+import { mix } from "yonius";
 
-import { genIdProps } from "../../../util";
+import { IdentifiableMixin } from "../../../util";
 
 import { Touchable } from "../touchable";
 
-export class Avatar extends PureComponent {
+export class Avatar extends mix(PureComponent).with(IdentifiableMixin) {
     static get propTypes() {
         return {
             image: PropTypes.oneOfType([PropTypes.number, PropTypes.object]).isRequired,
@@ -38,6 +39,7 @@ export class Avatar extends PureComponent {
     }
 
     _style = () => {
+        console.log("aqui");
         return [
             styles.avatar,
             {
@@ -62,7 +64,7 @@ export class Avatar extends PureComponent {
                     source={this.props.image}
                     style={styles.image}
                     resizeMode={this.props.resizeMode}
-                    {...genIdProps(this.props.idPrefix, "avatar")}
+                    {...this.id("avatar")}
                 />
             </Touchable>
         );

--- a/react/components/atoms/avatar/avatar.js
+++ b/react/components/atoms/avatar/avatar.js
@@ -64,7 +64,7 @@ export class Avatar extends PureComponent {
                     source={this.props.image}
                     style={styles.image}
                     resizeMode={this.props.resizeMode}
-                    {...this.props.testId ? testId(this.props.testId) : {}}
+                    {...(this.props.testId ? testId(this.props.testId) : {})}
                 />
             </Touchable>
         );

--- a/react/components/atoms/button-icon/button-icon.js
+++ b/react/components/atoms/button-icon/button-icon.js
@@ -2,6 +2,8 @@ import React, { PureComponent } from "react";
 import { StyleSheet, ViewPropTypes, TouchableOpacity } from "react-native";
 import PropTypes from "prop-types";
 
+import { genTestId } from "../../../util";
+
 import { Icon } from "../icon";
 
 export class ButtonIcon extends PureComponent {
@@ -22,8 +24,7 @@ export class ButtonIcon extends PureComponent {
                 left: PropTypes.number
             }),
             onPress: PropTypes.func,
-            style: ViewPropTypes.style,
-            testId: PropTypes.string
+            style: ViewPropTypes.style
         };
     }
 
@@ -43,8 +44,7 @@ export class ButtonIcon extends PureComponent {
                 left: 20
             },
             onPress: undefined,
-            style: {},
-            testId: undefined
+            style: {}
         };
     }
 
@@ -75,7 +75,7 @@ export class ButtonIcon extends PureComponent {
                     width={this.props.iconWidth}
                     height={this.props.iconHeight}
                     strokeWidth={this.props.iconStrokeWidth}
-                    testId={this.props.testId || `button-icon-${this.props.icon}`}
+                    testPrefix={genTestId(this.props.testPrefix, "button-icon")}
                 />
             </TouchableOpacity>
         );

--- a/react/components/atoms/button-icon/button-icon.js
+++ b/react/components/atoms/button-icon/button-icon.js
@@ -22,7 +22,8 @@ export class ButtonIcon extends PureComponent {
                 left: PropTypes.number
             }),
             onPress: PropTypes.func,
-            style: ViewPropTypes.style
+            style: ViewPropTypes.style,
+            testId: PropTypes.string
         };
     }
 
@@ -42,7 +43,8 @@ export class ButtonIcon extends PureComponent {
                 left: 20
             },
             onPress: undefined,
-            style: {}
+            style: {},
+            testId: undefined
         };
     }
 
@@ -73,6 +75,7 @@ export class ButtonIcon extends PureComponent {
                     width={this.props.iconWidth}
                     height={this.props.iconHeight}
                     strokeWidth={this.props.iconStrokeWidth}
+                    testId={(this.props.testId || `button-icon-${this.props.icon}`)}
                 />
             </TouchableOpacity>
         );

--- a/react/components/atoms/button-icon/button-icon.js
+++ b/react/components/atoms/button-icon/button-icon.js
@@ -1,12 +1,13 @@
 import React, { PureComponent } from "react";
 import { StyleSheet, ViewPropTypes, TouchableOpacity } from "react-native";
 import PropTypes from "prop-types";
+import { mix } from "yonius";
 
-import { genIdProps } from "../../../util";
+import { IdentifiableMixin } from "../../../util";
 
 import { Icon } from "../icon";
 
-export class ButtonIcon extends PureComponent {
+export class ButtonIcon extends mix(PureComponent).with(IdentifiableMixin) {
     static get propTypes() {
         return {
             icon: PropTypes.string.isRequired,
@@ -75,7 +76,7 @@ export class ButtonIcon extends PureComponent {
                     width={this.props.iconWidth}
                     height={this.props.iconHeight}
                     strokeWidth={this.props.iconStrokeWidth}
-                    {...genIdProps(this.props.idPrefix, "button-icon")}
+                    {...this.id("button-icon")}
                 />
             </TouchableOpacity>
         );

--- a/react/components/atoms/button-icon/button-icon.js
+++ b/react/components/atoms/button-icon/button-icon.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import { StyleSheet, ViewPropTypes, TouchableOpacity } from "react-native";
 import PropTypes from "prop-types";
 
-import { genTestId } from "../../../util";
+import { genIdProps } from "../../../util";
 
 import { Icon } from "../icon";
 
@@ -75,7 +75,7 @@ export class ButtonIcon extends PureComponent {
                     width={this.props.iconWidth}
                     height={this.props.iconHeight}
                     strokeWidth={this.props.iconStrokeWidth}
-                    testPrefix={genTestId(this.props.testPrefix, "button-icon")}
+                    {...genIdProps(this.props.idPrefix, "button-icon")}
                 />
             </TouchableOpacity>
         );

--- a/react/components/atoms/button-icon/button-icon.js
+++ b/react/components/atoms/button-icon/button-icon.js
@@ -75,7 +75,7 @@ export class ButtonIcon extends PureComponent {
                     width={this.props.iconWidth}
                     height={this.props.iconHeight}
                     strokeWidth={this.props.iconStrokeWidth}
-                    testId={(this.props.testId || `button-icon-${this.props.icon}`)}
+                    testId={this.props.testId || `button-icon-${this.props.icon}`}
                 />
             </TouchableOpacity>
         );

--- a/react/components/atoms/button-keyboard/button-keyboard.js
+++ b/react/components/atoms/button-keyboard/button-keyboard.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import { StyleSheet, Platform, Text, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 
-import { baseStyles, capitalize, isTabletSize, testId } from "../../../util";
+import { baseStyles, capitalize, isTabletSize, genTestProps } from "../../../util";
 
 import { Icon } from "../icon";
 import { Touchable } from "../touchable";
@@ -62,7 +62,7 @@ export class ButtonKeyboard extends PureComponent {
                 {this.props.text ? (
                     <Text
                         style={styles.text}
-                        {...testId(this.props.testId || `button-keyboard-${this.props.text}`)}
+                        {...genTestProps(this.props.testId || `button-keyboard-${this.props.text}`)}
                     >
                         {this.props.text}
                     </Text>

--- a/react/components/atoms/button-keyboard/button-keyboard.js
+++ b/react/components/atoms/button-keyboard/button-keyboard.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import { StyleSheet, Platform, Text, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 
-import { baseStyles, capitalize, isTabletSize } from "../../../util";
+import { baseStyles, capitalize, isTabletSize, testId } from "../../../util";
 
 import { Icon } from "../icon";
 import { Touchable } from "../touchable";
@@ -17,7 +17,8 @@ export class ButtonKeyboard extends PureComponent {
             variant: PropTypes.string,
             onPress: PropTypes.func,
             onLongPress: PropTypes.func,
-            style: ViewPropTypes.style
+            style: ViewPropTypes.style,
+            testId: PropTypes.string
         };
     }
 
@@ -30,7 +31,8 @@ export class ButtonKeyboard extends PureComponent {
             variant: undefined,
             onPress: () => {},
             onLongPress: () => {},
-            style: {}
+            style: {},
+            testId: undefined
         };
     }
 
@@ -57,12 +59,13 @@ export class ButtonKeyboard extends PureComponent {
                 onPress={this._onPress}
                 onLongPress={this._onLongPress}
             >
-                {this.props.text ? <Text style={styles.text}>{this.props.text}</Text> : null}
+                {this.props.text ? <Text style={styles.text} {...testId(this.props.testId || `button-keyboard-${this.props.text}`)}>{this.props.text}</Text> : null}
                 {this.props.icon ? (
                     <Icon
                         icon={this.props.icon}
                         strokeWidth={this.props.strokeWidth}
                         color="#17425c"
+                        testId={this.props.testId || `button-keyboard-${this.props.icon}`}
                     />
                 ) : null}
             </Touchable>

--- a/react/components/atoms/button-keyboard/button-keyboard.js
+++ b/react/components/atoms/button-keyboard/button-keyboard.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import { StyleSheet, Platform, Text, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 
-import { baseStyles, capitalize, isTabletSize, genTestProps } from "../../../util";
+import { baseStyles, capitalize, isTabletSize, genTestId, genTestProps } from "../../../util";
 
 import { Icon } from "../icon";
 import { Touchable } from "../touchable";
@@ -17,8 +17,7 @@ export class ButtonKeyboard extends PureComponent {
             variant: PropTypes.string,
             onPress: PropTypes.func,
             onLongPress: PropTypes.func,
-            style: ViewPropTypes.style,
-            testId: PropTypes.string
+            style: ViewPropTypes.style
         };
     }
 
@@ -31,8 +30,7 @@ export class ButtonKeyboard extends PureComponent {
             variant: undefined,
             onPress: () => {},
             onLongPress: () => {},
-            style: {},
-            testId: undefined
+            style: {}
         };
     }
 
@@ -62,7 +60,7 @@ export class ButtonKeyboard extends PureComponent {
                 {this.props.text ? (
                     <Text
                         style={styles.text}
-                        {...genTestProps(this.props.testId || `button-keyboard-${this.props.text}`)}
+                        {...genTestProps(this.props.testPrefix, `button-keyboard-${this.props.text}`)}
                     >
                         {this.props.text}
                     </Text>
@@ -72,7 +70,7 @@ export class ButtonKeyboard extends PureComponent {
                         icon={this.props.icon}
                         strokeWidth={this.props.strokeWidth}
                         color="#17425c"
-                        testId={this.props.testId || `button-keyboard-${this.props.icon}`}
+                        testPrefix={genTestId(this.props.testPrefix, `button-keyboard-${this.props.icon}`)}
                     />
                 ) : null}
             </Touchable>

--- a/react/components/atoms/button-keyboard/button-keyboard.js
+++ b/react/components/atoms/button-keyboard/button-keyboard.js
@@ -60,7 +60,10 @@ export class ButtonKeyboard extends PureComponent {
                 {this.props.text ? (
                     <Text
                         style={styles.text}
-                        {...genTestProps(this.props.testPrefix, `button-keyboard-${this.props.text}`)}
+                        {...genTestProps(
+                            this.props.testPrefix,
+                            `button-keyboard-${this.props.text}`
+                        )}
                     >
                         {this.props.text}
                     </Text>
@@ -70,7 +73,10 @@ export class ButtonKeyboard extends PureComponent {
                         icon={this.props.icon}
                         strokeWidth={this.props.strokeWidth}
                         color="#17425c"
-                        testPrefix={genTestId(this.props.testPrefix, `button-keyboard-${this.props.icon}`)}
+                        testPrefix={genTestId(
+                            this.props.testPrefix,
+                            `button-keyboard-${this.props.icon}`
+                        )}
                     />
                 ) : null}
             </Touchable>

--- a/react/components/atoms/button-keyboard/button-keyboard.js
+++ b/react/components/atoms/button-keyboard/button-keyboard.js
@@ -1,13 +1,14 @@
 import React, { PureComponent } from "react";
 import { StyleSheet, Platform, Text, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
+import { mix } from "yonius";
 
-import { baseStyles, capitalize, isTabletSize, genIdProps } from "../../../util";
+import { IdentifiableMixin, baseStyles, capitalize, isTabletSize } from "../../../util";
 
 import { Icon } from "../icon";
 import { Touchable } from "../touchable";
 
-export class ButtonKeyboard extends PureComponent {
+export class ButtonKeyboard extends mix(PureComponent).with(IdentifiableMixin) {
     static get propTypes() {
         return {
             icon: PropTypes.string,
@@ -58,10 +59,7 @@ export class ButtonKeyboard extends PureComponent {
                 onLongPress={this._onLongPress}
             >
                 {this.props.text ? (
-                    <Text
-                        style={styles.text}
-                        {...genIdProps(this.props.idPrefix, `button-keyboard-${this.props.text}`)}
-                    >
+                    <Text style={styles.text} {...this.id(`button-keyboard-${this.props.text}`)}>
                         {this.props.text}
                     </Text>
                 ) : null}
@@ -70,7 +68,7 @@ export class ButtonKeyboard extends PureComponent {
                         icon={this.props.icon}
                         strokeWidth={this.props.strokeWidth}
                         color="#17425c"
-                        {...genIdProps(this.props.idPrefix, `button-keyboard-${this.props.icon}`)}
+                        {...this.id(`button-keyboard-${this.props.icon}`)}
                     />
                 ) : null}
             </Touchable>

--- a/react/components/atoms/button-keyboard/button-keyboard.js
+++ b/react/components/atoms/button-keyboard/button-keyboard.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import { StyleSheet, Platform, Text, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 
-import { baseStyles, capitalize, isTabletSize, genTestId, genTestProps } from "../../../util";
+import { baseStyles, capitalize, isTabletSize, genIdProps } from "../../../util";
 
 import { Icon } from "../icon";
 import { Touchable } from "../touchable";
@@ -60,10 +60,7 @@ export class ButtonKeyboard extends PureComponent {
                 {this.props.text ? (
                     <Text
                         style={styles.text}
-                        {...genTestProps(
-                            this.props.testPrefix,
-                            `button-keyboard-${this.props.text}`
-                        )}
+                        {...genIdProps(this.props.idPrefix, `button-keyboard-${this.props.text}`)}
                     >
                         {this.props.text}
                     </Text>
@@ -73,10 +70,7 @@ export class ButtonKeyboard extends PureComponent {
                         icon={this.props.icon}
                         strokeWidth={this.props.strokeWidth}
                         color="#17425c"
-                        testPrefix={genTestId(
-                            this.props.testPrefix,
-                            `button-keyboard-${this.props.icon}`
-                        )}
+                        {...genIdProps(this.props.idPrefix, `button-keyboard-${this.props.icon}`)}
                     />
                 ) : null}
             </Touchable>

--- a/react/components/atoms/button-keyboard/button-keyboard.js
+++ b/react/components/atoms/button-keyboard/button-keyboard.js
@@ -59,7 +59,14 @@ export class ButtonKeyboard extends PureComponent {
                 onPress={this._onPress}
                 onLongPress={this._onLongPress}
             >
-                {this.props.text ? <Text style={styles.text} {...testId(this.props.testId || `button-keyboard-${this.props.text}`)}>{this.props.text}</Text> : null}
+                {this.props.text ? (
+                    <Text
+                        style={styles.text}
+                        {...testId(this.props.testId || `button-keyboard-${this.props.text}`)}
+                    >
+                        {this.props.text}
+                    </Text>
+                ) : null}
                 {this.props.icon ? (
                     <Icon
                         icon={this.props.icon}

--- a/react/components/atoms/button-tab-text/button-tab-text.js
+++ b/react/components/atoms/button-tab-text/button-tab-text.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import { ViewPropTypes, StyleSheet, Platform, Text } from "react-native";
 import PropTypes from "prop-types";
 
-import { baseStyles, capitalize, genTestProps } from "../../../util";
+import { baseStyles, capitalize, genIdProps } from "../../../util";
 
 import { Touchable } from "../touchable";
 
@@ -66,7 +66,7 @@ export class ButtonTabText extends PureComponent {
             >
                 <Text
                     style={this._styleText()}
-                    {...genTestProps(this.props.testPrefix, "button-tab-text")}
+                    {...genIdProps(this.props.idPrefix, "button-tab-text")}
                 >
                     {this.props.text}
                 </Text>

--- a/react/components/atoms/button-tab-text/button-tab-text.js
+++ b/react/components/atoms/button-tab-text/button-tab-text.js
@@ -17,8 +17,7 @@ export class ButtonTabText extends PureComponent {
             activeOpacity: PropTypes.number,
             variant: PropTypes.string,
             onPress: PropTypes.func,
-            style: ViewPropTypes.style,
-            testId: PropTypes.string
+            style: ViewPropTypes.style
         };
     }
 
@@ -32,8 +31,7 @@ export class ButtonTabText extends PureComponent {
             activeOpacity: 0.5,
             variant: undefined,
             onPress: undefined,
-            style: {},
-            testId: undefined
+            style: {}
         };
     }
 
@@ -68,7 +66,7 @@ export class ButtonTabText extends PureComponent {
             >
                 <Text
                     style={this._styleText()}
-                    {...genTestProps(this.props.testId || `button-tab-text-${this.props.text}`)}
+                    {...genTestProps(this.props.testPrefix, "button-tab-text")}
                 >
                     {this.props.text}
                 </Text>

--- a/react/components/atoms/button-tab-text/button-tab-text.js
+++ b/react/components/atoms/button-tab-text/button-tab-text.js
@@ -66,7 +66,12 @@ export class ButtonTabText extends PureComponent {
                 activeOpacity={this.props.activeOpacity}
                 onPress={this.props.onPress}
             >
-                <Text style={this._styleText()} {...testId(this.props.testId || `button-tab-text-${this.props.text}`)}>{this.props.text}</Text>
+                <Text
+                    style={this._styleText()}
+                    {...testId(this.props.testId || `button-tab-text-${this.props.text}`)}
+                >
+                    {this.props.text}
+                </Text>
             </Touchable>
         );
     }

--- a/react/components/atoms/button-tab-text/button-tab-text.js
+++ b/react/components/atoms/button-tab-text/button-tab-text.js
@@ -1,12 +1,13 @@
 import React, { PureComponent } from "react";
 import { ViewPropTypes, StyleSheet, Platform, Text } from "react-native";
 import PropTypes from "prop-types";
+import { mix } from "yonius";
 
-import { baseStyles, capitalize, genIdProps } from "../../../util";
+import { IdentifiableMixin, baseStyles, capitalize } from "../../../util";
 
 import { Touchable } from "../touchable";
 
-export class ButtonTabText extends PureComponent {
+export class ButtonTabText extends mix(PureComponent).with(IdentifiableMixin) {
     static get propTypes() {
         return {
             active: PropTypes.bool,
@@ -64,10 +65,7 @@ export class ButtonTabText extends PureComponent {
                 activeOpacity={this.props.activeOpacity}
                 onPress={this.props.onPress}
             >
-                <Text
-                    style={this._styleText()}
-                    {...genIdProps(this.props.idPrefix, "button-tab-text")}
-                >
+                <Text style={this._styleText()} {...this.id("button-tab-text")}>
                     {this.props.text}
                 </Text>
             </Touchable>

--- a/react/components/atoms/button-tab-text/button-tab-text.js
+++ b/react/components/atoms/button-tab-text/button-tab-text.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import { ViewPropTypes, StyleSheet, Platform, Text } from "react-native";
 import PropTypes from "prop-types";
 
-import { baseStyles, capitalize, testId } from "../../../util";
+import { baseStyles, capitalize, genTestProps } from "../../../util";
 
 import { Touchable } from "../touchable";
 
@@ -68,7 +68,7 @@ export class ButtonTabText extends PureComponent {
             >
                 <Text
                     style={this._styleText()}
-                    {...testId(this.props.testId || `button-tab-text-${this.props.text}`)}
+                    {...genTestProps(this.props.testId || `button-tab-text-${this.props.text}`)}
                 >
                     {this.props.text}
                 </Text>

--- a/react/components/atoms/button-tab-text/button-tab-text.js
+++ b/react/components/atoms/button-tab-text/button-tab-text.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import { ViewPropTypes, StyleSheet, Platform, Text } from "react-native";
 import PropTypes from "prop-types";
 
-import { baseStyles, capitalize } from "../../../util";
+import { baseStyles, capitalize, testId } from "../../../util";
 
 import { Touchable } from "../touchable";
 
@@ -17,7 +17,8 @@ export class ButtonTabText extends PureComponent {
             activeOpacity: PropTypes.number,
             variant: PropTypes.string,
             onPress: PropTypes.func,
-            style: ViewPropTypes.style
+            style: ViewPropTypes.style,
+            testId: PropTypes.string
         };
     }
 
@@ -31,7 +32,8 @@ export class ButtonTabText extends PureComponent {
             activeOpacity: 0.5,
             variant: undefined,
             onPress: undefined,
-            style: {}
+            style: {},
+            testId: undefined
         };
     }
 
@@ -64,7 +66,7 @@ export class ButtonTabText extends PureComponent {
                 activeOpacity={this.props.activeOpacity}
                 onPress={this.props.onPress}
             >
-                <Text style={this._styleText()}>{this.props.text}</Text>
+                <Text style={this._styleText()} {...testId(this.props.testId || `button-tab-text-${this.props.text}`)}>{this.props.text}</Text>
             </Touchable>
         );
     }

--- a/react/components/atoms/button-tab/button-tab.js
+++ b/react/components/atoms/button-tab/button-tab.js
@@ -9,13 +9,14 @@ import {
     Platform
 } from "react-native";
 import PropTypes from "prop-types";
+import { mix } from "yonius";
 
-import { baseStyles, genIdProps } from "../../../util";
+import { IdentifiableMixin, baseStyles } from "../../../util";
 
 import { Icon } from "../icon";
 import { Badge } from "../badge";
 
-export class ButtonTab extends PureComponent {
+export class ButtonTab extends mix(PureComponent).with(IdentifiableMixin) {
     state = {
         pressed: false
     };
@@ -93,10 +94,7 @@ export class ButtonTab extends PureComponent {
                     <Icon icon={this.props.icon} color={this._iconColor()} strokeWidth={2.5} />
                 ) : null}
                 {this.props.text ? (
-                    <Text
-                        {...genIdProps(this.props.idPrefix, `button-tab-${this.props.text}`)}
-                        style={this._labelStyle()}
-                    >
+                    <Text {...this.id(`button-tab-${this.props.text}`)} style={this._labelStyle()}>
                         {this.props.text}
                     </Text>
                 ) : null}

--- a/react/components/atoms/button-tab/button-tab.js
+++ b/react/components/atoms/button-tab/button-tab.js
@@ -10,7 +10,7 @@ import {
 } from "react-native";
 import PropTypes from "prop-types";
 
-import { baseStyles, genTestProps } from "../../../util";
+import { baseStyles, genIdProps } from "../../../util";
 
 import { Icon } from "../icon";
 import { Badge } from "../badge";
@@ -94,7 +94,7 @@ export class ButtonTab extends PureComponent {
                 ) : null}
                 {this.props.text ? (
                     <Text
-                        {...genTestProps(this.props.testPrefix, `button-tab-${this.props.text}`)}
+                        {...genIdProps(this.props.idPrefix, `button-tab-${this.props.text}`)}
                         style={this._labelStyle()}
                     >
                         {this.props.text}

--- a/react/components/atoms/button-tab/button-tab.js
+++ b/react/components/atoms/button-tab/button-tab.js
@@ -10,7 +10,7 @@ import {
 } from "react-native";
 import PropTypes from "prop-types";
 
-import { baseStyles } from "../../../util";
+import { baseStyles, testId } from "../../../util";
 
 import { Icon } from "../icon";
 import { Badge } from "../badge";
@@ -35,8 +35,9 @@ export class ButtonTab extends PureComponent {
             colorSelected: PropTypes.string,
             selected: PropTypes.bool,
             disabled: PropTypes.bool,
+            onPress: PropTypes.func,
             style: ViewPropTypes.style,
-            onPress: PropTypes.func
+            testId: PropTypes.string
         };
     }
 
@@ -54,8 +55,9 @@ export class ButtonTab extends PureComponent {
             colorSelected: "#1d2631",
             selected: false,
             disabled: false,
+            onPress: () => {},
             style: {},
-            onPress: () => {}
+            testId: undefined
         };
     }
 
@@ -92,7 +94,7 @@ export class ButtonTab extends PureComponent {
                 {this.props.icon ? (
                     <Icon icon={this.props.icon} color={this._iconColor()} strokeWidth={2.5} />
                 ) : null}
-                {this.props.text ? <Text style={this._labelStyle()}>{this.props.text}</Text> : null}
+                {this.props.text ? <Text {...testId(this.props.testId || `button-tab-${this.props.text}`)} style={this._labelStyle()}>{this.props.text}</Text> : null}
                 {this.props.badgeCount > 0 ? (
                     <Badge
                         animationDuration={this.props.badgeAnimationDuration}

--- a/react/components/atoms/button-tab/button-tab.js
+++ b/react/components/atoms/button-tab/button-tab.js
@@ -10,7 +10,7 @@ import {
 } from "react-native";
 import PropTypes from "prop-types";
 
-import { baseStyles, testId } from "../../../util";
+import { baseStyles, genTestProps } from "../../../util";
 
 import { Icon } from "../icon";
 import { Badge } from "../badge";
@@ -96,7 +96,7 @@ export class ButtonTab extends PureComponent {
                 ) : null}
                 {this.props.text ? (
                     <Text
-                        {...testId(this.props.testId || `button-tab-${this.props.text}`)}
+                        {...genTestProps(this.props.testId || `button-tab-${this.props.text}`)}
                         style={this._labelStyle()}
                     >
                         {this.props.text}

--- a/react/components/atoms/button-tab/button-tab.js
+++ b/react/components/atoms/button-tab/button-tab.js
@@ -36,8 +36,7 @@ export class ButtonTab extends PureComponent {
             selected: PropTypes.bool,
             disabled: PropTypes.bool,
             onPress: PropTypes.func,
-            style: ViewPropTypes.style,
-            testId: PropTypes.string
+            style: ViewPropTypes.style
         };
     }
 
@@ -56,8 +55,7 @@ export class ButtonTab extends PureComponent {
             selected: false,
             disabled: false,
             onPress: () => {},
-            style: {},
-            testId: undefined
+            style: {}
         };
     }
 
@@ -96,7 +94,7 @@ export class ButtonTab extends PureComponent {
                 ) : null}
                 {this.props.text ? (
                     <Text
-                        {...genTestProps(this.props.testId || `button-tab-${this.props.text}`)}
+                        {...genTestProps(this.props.testPrefix, `button-tab-${this.props.text}`)}
                         style={this._labelStyle()}
                     >
                         {this.props.text}

--- a/react/components/atoms/button-tab/button-tab.js
+++ b/react/components/atoms/button-tab/button-tab.js
@@ -94,7 +94,14 @@ export class ButtonTab extends PureComponent {
                 {this.props.icon ? (
                     <Icon icon={this.props.icon} color={this._iconColor()} strokeWidth={2.5} />
                 ) : null}
-                {this.props.text ? <Text {...testId(this.props.testId || `button-tab-${this.props.text}`)} style={this._labelStyle()}>{this.props.text}</Text> : null}
+                {this.props.text ? (
+                    <Text
+                        {...testId(this.props.testId || `button-tab-${this.props.text}`)}
+                        style={this._labelStyle()}
+                    >
+                        {this.props.text}
+                    </Text>
+                ) : null}
                 {this.props.badgeCount > 0 ? (
                     <Badge
                         animationDuration={this.props.badgeAnimationDuration}

--- a/react/components/atoms/button/button.js
+++ b/react/components/atoms/button/button.js
@@ -62,7 +62,10 @@ export class Button extends PureComponent {
 
     _renderNormal() {
         return (
-            <View style={styles.container} {...testId(this.props.testId || `button-${this.props.text}`)}>
+            <View
+                style={styles.container}
+                {...testId(this.props.testId || `button-${this.props.text}`)}
+            >
                 {this.props.icon ? (
                     <Icon
                         icon={this.props.icon}

--- a/react/components/atoms/button/button.js
+++ b/react/components/atoms/button/button.js
@@ -3,7 +3,7 @@ import { StyleSheet, Text, ActivityIndicator, ViewPropTypes, Platform, View } fr
 import LinearGradient from "react-native-linear-gradient";
 import PropTypes from "prop-types";
 
-import { baseStyles, genTestProps } from "../../../util";
+import { baseStyles, genIdProps } from "../../../util";
 
 import { Icon } from "../icon";
 import { Touchable } from "../touchable";
@@ -62,7 +62,7 @@ export class Button extends PureComponent {
         return (
             <View
                 style={styles.container}
-                {...genTestProps(this.props.testPrefix, `button-${this.props.text}`)}
+                {...genIdProps(this.props.idPrefix, `button-${this.props.text}`)}
             >
                 {this.props.icon ? (
                     <Icon

--- a/react/components/atoms/button/button.js
+++ b/react/components/atoms/button/button.js
@@ -3,7 +3,7 @@ import { StyleSheet, Text, ActivityIndicator, ViewPropTypes, Platform, View } fr
 import LinearGradient from "react-native-linear-gradient";
 import PropTypes from "prop-types";
 
-import { baseStyles, testId } from "../../../util";
+import { baseStyles, genTestProps } from "../../../util";
 
 import { Icon } from "../icon";
 import { Touchable } from "../touchable";
@@ -64,7 +64,7 @@ export class Button extends PureComponent {
         return (
             <View
                 style={styles.container}
-                {...testId(this.props.testId || `button-${this.props.text}`)}
+                {...genTestProps(this.props.testId || `button-${this.props.text}`)}
             >
                 {this.props.icon ? (
                     <Icon

--- a/react/components/atoms/button/button.js
+++ b/react/components/atoms/button/button.js
@@ -3,7 +3,7 @@ import { StyleSheet, Text, ActivityIndicator, ViewPropTypes, Platform, View } fr
 import LinearGradient from "react-native-linear-gradient";
 import PropTypes from "prop-types";
 
-import { baseStyles } from "../../../util";
+import { baseStyles, testId } from "../../../util";
 
 import { Icon } from "../icon";
 import { Touchable } from "../touchable";
@@ -22,8 +22,9 @@ export class Button extends PureComponent {
             gradientStart: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),
             gradientEnd: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),
             width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+            onPress: PropTypes.func,
             style: ViewPropTypes.style,
-            onPress: PropTypes.func
+            testId: PropTypes.string
         };
     }
 
@@ -37,8 +38,9 @@ export class Button extends PureComponent {
             gradientLocations: [0.4, 0.84],
             gradientColors: ["#4a6fe9", "#6687f6"],
             width: undefined,
+            onPress: () => {},
             style: {},
-            onPress: () => {}
+            testId: undefined
         };
     }
 
@@ -60,7 +62,7 @@ export class Button extends PureComponent {
 
     _renderNormal() {
         return (
-            <View style={styles.container}>
+            <View style={styles.container} {...testId(this.props.testId || `button-${this.props.text}`)}>
                 {this.props.icon ? (
                     <Icon
                         icon={this.props.icon}

--- a/react/components/atoms/button/button.js
+++ b/react/components/atoms/button/button.js
@@ -23,8 +23,7 @@ export class Button extends PureComponent {
             gradientEnd: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),
             width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
             onPress: PropTypes.func,
-            style: ViewPropTypes.style,
-            testId: PropTypes.string
+            style: ViewPropTypes.style
         };
     }
 
@@ -39,8 +38,7 @@ export class Button extends PureComponent {
             gradientColors: ["#4a6fe9", "#6687f6"],
             width: undefined,
             onPress: () => {},
-            style: {},
-            testId: undefined
+            style: {}
         };
     }
 
@@ -64,7 +62,7 @@ export class Button extends PureComponent {
         return (
             <View
                 style={styles.container}
-                {...genTestProps(this.props.testId || `button-${this.props.text}`)}
+                {...genTestProps(this.props.testPrefix, `button-${this.props.text}`)}
             >
                 {this.props.icon ? (
                     <Icon

--- a/react/components/atoms/button/button.js
+++ b/react/components/atoms/button/button.js
@@ -2,13 +2,14 @@ import React, { PureComponent } from "react";
 import { StyleSheet, Text, ActivityIndicator, ViewPropTypes, Platform, View } from "react-native";
 import LinearGradient from "react-native-linear-gradient";
 import PropTypes from "prop-types";
+import { mix } from "yonius";
 
-import { baseStyles, genIdProps } from "../../../util";
+import { IdentifiableMixin, baseStyles } from "../../../util";
 
 import { Icon } from "../icon";
 import { Touchable } from "../touchable";
 
-export class Button extends PureComponent {
+export class Button extends mix(PureComponent).with(IdentifiableMixin) {
     static get propTypes() {
         return {
             text: PropTypes.string.isRequired,
@@ -60,10 +61,7 @@ export class Button extends PureComponent {
 
     _renderNormal() {
         return (
-            <View
-                style={styles.container}
-                {...genIdProps(this.props.idPrefix, `button-${this.props.text}`)}
-            >
+            <View style={styles.container} {...this.id(`button-${this.props.text}`)}>
                 {this.props.icon ? (
                     <Icon
                         icon={this.props.icon}

--- a/react/components/atoms/icon/icon.js
+++ b/react/components/atoms/icon/icon.js
@@ -22,8 +22,7 @@ export class Icon extends PureComponent {
             ]),
             height: PropTypes.number,
             width: PropTypes.number,
-            style: ViewPropTypes.style,
-            testId: PropTypes.string
+            style: ViewPropTypes.style
         };
     }
 
@@ -34,8 +33,7 @@ export class Icon extends PureComponent {
             height: 20,
             width: 20,
             strokeWidth: 1.5,
-            style: {},
-            testId: undefined
+            style: {}
         };
     }
 
@@ -54,7 +52,7 @@ export class Icon extends PureComponent {
                 stroke={this.props.color}
                 strokeWidth={this.props.strokeWidth}
                 style={this.props.style}
-                {...genTestProps(this.props.testId || `icon-${this.props.icon}`)}
+                {...genTestProps(this.props.testPrefix, `icon-${this.props.icon}`)}
             />
         );
     }

--- a/react/components/atoms/icon/icon.js
+++ b/react/components/atoms/icon/icon.js
@@ -3,7 +3,7 @@ import { ViewPropTypes } from "react-native";
 import { SvgXml } from "react-native-svg";
 import PropTypes from "prop-types";
 
-import { genTestProps } from "../../../util";
+import { genIdProps } from "../../../util";
 import icons from "../../../assets/icons/";
 
 export class Icon extends PureComponent {
@@ -52,7 +52,7 @@ export class Icon extends PureComponent {
                 stroke={this.props.color}
                 strokeWidth={this.props.strokeWidth}
                 style={this.props.style}
-                {...genTestProps(this.props.testPrefix, `icon-${this.props.icon}`)}
+                {...genIdProps(this.props.idPrefix, `icon-${this.props.icon}`)}
             />
         );
     }

--- a/react/components/atoms/icon/icon.js
+++ b/react/components/atoms/icon/icon.js
@@ -3,6 +3,7 @@ import { ViewPropTypes } from "react-native";
 import { SvgXml } from "react-native-svg";
 import PropTypes from "prop-types";
 
+import { testId } from "../../../util";
 import icons from "../../../assets/icons/";
 
 export class Icon extends PureComponent {
@@ -21,7 +22,8 @@ export class Icon extends PureComponent {
             ]),
             height: PropTypes.number,
             width: PropTypes.number,
-            style: ViewPropTypes.style
+            style: ViewPropTypes.style,
+            testId: PropTypes.string
         };
     }
 
@@ -32,7 +34,8 @@ export class Icon extends PureComponent {
             height: 20,
             width: 20,
             strokeWidth: 1.5,
-            style: {}
+            style: {},
+            testId: undefined
         };
     }
 
@@ -51,6 +54,7 @@ export class Icon extends PureComponent {
                 stroke={this.props.color}
                 strokeWidth={this.props.strokeWidth}
                 style={this.props.style}
+                {...testId(this.props.testId || `icon-${this.props.icon}`)}
             />
         );
     }

--- a/react/components/atoms/icon/icon.js
+++ b/react/components/atoms/icon/icon.js
@@ -3,7 +3,7 @@ import { ViewPropTypes } from "react-native";
 import { SvgXml } from "react-native-svg";
 import PropTypes from "prop-types";
 
-import { testId } from "../../../util";
+import { genTestProps } from "../../../util";
 import icons from "../../../assets/icons/";
 
 export class Icon extends PureComponent {
@@ -54,7 +54,7 @@ export class Icon extends PureComponent {
                 stroke={this.props.color}
                 strokeWidth={this.props.strokeWidth}
                 style={this.props.style}
-                {...testId(this.props.testId || `icon-${this.props.icon}`)}
+                {...genTestProps(this.props.testId || `icon-${this.props.icon}`)}
             />
         );
     }

--- a/react/components/atoms/icon/icon.js
+++ b/react/components/atoms/icon/icon.js
@@ -2,11 +2,12 @@ import React, { PureComponent } from "react";
 import { ViewPropTypes } from "react-native";
 import { SvgXml } from "react-native-svg";
 import PropTypes from "prop-types";
+import { mix } from "yonius";
 
-import { genIdProps } from "../../../util";
+import { IdentifiableMixin } from "../../../util";
 import icons from "../../../assets/icons/";
 
-export class Icon extends PureComponent {
+export class Icon extends mix(PureComponent).with(IdentifiableMixin) {
     static get propTypes() {
         return {
             icon: PropTypes.string.isRequired,
@@ -52,7 +53,7 @@ export class Icon extends PureComponent {
                 stroke={this.props.color}
                 strokeWidth={this.props.strokeWidth}
                 style={this.props.style}
-                {...genIdProps(this.props.idPrefix, `icon-${this.props.icon}`)}
+                {...this.id(`icon-${this.props.icon}`)}
             />
         );
     }

--- a/react/components/atoms/tag/tag.js
+++ b/react/components/atoms/tag/tag.js
@@ -84,7 +84,14 @@ export class Tag extends PureComponent {
                         {...testId(this.props.testId || `tag-icon-${this.props.icon}`)}
                     />
                 ) : null}
-                {this.props.text ? <Text style={this._textStyle()} {...testId(this.props.testId || `tag-text-${this.props.text}`)}>{this.props.text}</Text> : null}
+                {this.props.text ? (
+                    <Text
+                        style={this._textStyle()}
+                        {...testId(this.props.testId || `tag-text-${this.props.text}`)}
+                    >
+                        {this.props.text}
+                    </Text>
+                ) : null}
             </Touchable>
         );
     }

--- a/react/components/atoms/tag/tag.js
+++ b/react/components/atoms/tag/tag.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import { StyleSheet, ViewPropTypes, Platform, Text } from "react-native";
 import PropTypes from "prop-types";
 
-import { baseStyles, capitalize, testId } from "../../../util";
+import { baseStyles, capitalize, genTestProps } from "../../../util";
 
 import { Icon } from "../icon";
 import { Touchable } from "../touchable";
@@ -81,13 +81,13 @@ export class Tag extends PureComponent {
                         color={this.props.color}
                         width={this.props.iconWidth}
                         height={this.props.iconHeight}
-                        {...testId(this.props.testId || `tag-icon-${this.props.icon}`)}
+                        {...genTestProps(this.props.testId || `tag-icon-${this.props.icon}`)}
                     />
                 ) : null}
                 {this.props.text ? (
                     <Text
                         style={this._textStyle()}
-                        {...testId(this.props.testId || `tag-text-${this.props.text}`)}
+                        {...genTestProps(this.props.testId || `tag-text-${this.props.text}`)}
                     >
                         {this.props.text}
                     </Text>

--- a/react/components/atoms/tag/tag.js
+++ b/react/components/atoms/tag/tag.js
@@ -19,8 +19,7 @@ export class Tag extends PureComponent {
             iconHeight: PropTypes.number,
             size: PropTypes.string,
             onPress: PropTypes.func,
-            style: ViewPropTypes.style,
-            testId: PropTypes.string
+            style: ViewPropTypes.style
         };
     }
 
@@ -35,8 +34,7 @@ export class Tag extends PureComponent {
             iconHeight: undefined,
             size: "normal",
             onPress: undefined,
-            style: {},
-            testId: undefined
+            style: {}
         };
     }
 
@@ -81,13 +79,13 @@ export class Tag extends PureComponent {
                         color={this.props.color}
                         width={this.props.iconWidth}
                         height={this.props.iconHeight}
-                        {...genTestProps(this.props.testId || `tag-icon-${this.props.icon}`)}
+                        {...genTestProps(this.props.testPrefix, "tag-icon")}
                     />
                 ) : null}
                 {this.props.text ? (
                     <Text
                         style={this._textStyle()}
-                        {...genTestProps(this.props.testId || `tag-text-${this.props.text}`)}
+                        {...genTestProps(this.props.testPrefix, "tag-text")}
                     >
                         {this.props.text}
                     </Text>

--- a/react/components/atoms/tag/tag.js
+++ b/react/components/atoms/tag/tag.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import { StyleSheet, ViewPropTypes, Platform, Text } from "react-native";
 import PropTypes from "prop-types";
 
-import { baseStyles, capitalize, genTestProps } from "../../../util";
+import { baseStyles, capitalize, genIdProps } from "../../../util";
 
 import { Icon } from "../icon";
 import { Touchable } from "../touchable";
@@ -79,13 +79,13 @@ export class Tag extends PureComponent {
                         color={this.props.color}
                         width={this.props.iconWidth}
                         height={this.props.iconHeight}
-                        {...genTestProps(this.props.testPrefix, "tag-icon")}
+                        {...genIdProps(this.props.idPrefix, "tag-icon")}
                     />
                 ) : null}
                 {this.props.text ? (
                     <Text
                         style={this._textStyle()}
-                        {...genTestProps(this.props.testPrefix, "tag-text")}
+                        {...genIdProps(this.props.idPrefix, "tag-text")}
                     >
                         {this.props.text}
                     </Text>

--- a/react/components/atoms/tag/tag.js
+++ b/react/components/atoms/tag/tag.js
@@ -1,13 +1,14 @@
 import React, { PureComponent } from "react";
 import { StyleSheet, ViewPropTypes, Platform, Text } from "react-native";
 import PropTypes from "prop-types";
+import { mix } from "yonius";
 
-import { baseStyles, capitalize, genIdProps } from "../../../util";
+import { IdentifiableMixin, baseStyles, capitalize } from "../../../util";
 
 import { Icon } from "../icon";
 import { Touchable } from "../touchable";
 
-export class Tag extends PureComponent {
+export class Tag extends mix(PureComponent).with(IdentifiableMixin) {
     static get propTypes() {
         return {
             color: PropTypes.string,
@@ -79,14 +80,11 @@ export class Tag extends PureComponent {
                         color={this.props.color}
                         width={this.props.iconWidth}
                         height={this.props.iconHeight}
-                        {...genIdProps(this.props.idPrefix, "tag-icon")}
+                        {...this.id("tag-icon")}
                     />
                 ) : null}
                 {this.props.text ? (
-                    <Text
-                        style={this._textStyle()}
-                        {...genIdProps(this.props.idPrefix, "tag-text")}
-                    >
+                    <Text style={this._textStyle()} {...this.id("tag-text")}>
                         {this.props.text}
                     </Text>
                 ) : null}

--- a/react/components/atoms/tag/tag.js
+++ b/react/components/atoms/tag/tag.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import { StyleSheet, ViewPropTypes, Platform, Text } from "react-native";
 import PropTypes from "prop-types";
 
-import { baseStyles, capitalize } from "../../../util";
+import { baseStyles, capitalize, testId } from "../../../util";
 
 import { Icon } from "../icon";
 import { Touchable } from "../touchable";
@@ -19,7 +19,8 @@ export class Tag extends PureComponent {
             iconHeight: PropTypes.number,
             size: PropTypes.string,
             onPress: PropTypes.func,
-            style: ViewPropTypes.style
+            style: ViewPropTypes.style,
+            testId: PropTypes.string
         };
     }
 
@@ -34,7 +35,8 @@ export class Tag extends PureComponent {
             iconHeight: undefined,
             size: "normal",
             onPress: undefined,
-            style: {}
+            style: {},
+            testId: undefined
         };
     }
 
@@ -79,9 +81,10 @@ export class Tag extends PureComponent {
                         color={this.props.color}
                         width={this.props.iconWidth}
                         height={this.props.iconHeight}
+                        {...testId(this.props.testId || `tag-icon-${this.props.icon}`)}
                     />
                 ) : null}
-                {this.props.text ? <Text style={this._textStyle()}>{this.props.text}</Text> : null}
+                {this.props.text ? <Text style={this._textStyle()} {...testId(this.props.testId || `tag-text-${this.props.text}`)}>{this.props.text}</Text> : null}
             </Touchable>
         );
     }

--- a/react/components/atoms/textarea/textarea.js
+++ b/react/components/atoms/textarea/textarea.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import { StyleSheet, ViewPropTypes, TextInput } from "react-native";
 import PropTypes from "prop-types";
 
-import { capitalize, baseStyles, testId } from "../../../util";
+import { capitalize, baseStyles, genTestProps } from "../../../util";
 
 export class TextArea extends PureComponent {
     static get propTypes() {
@@ -79,7 +79,7 @@ export class TextArea extends PureComponent {
                 onChangeText={this.props.onValue}
                 onFocus={this.props.onFocus}
                 onBlur={this.props.onBlur}
-                {...(this._testId() ? testId(`textarea-${this._testId()}`) : {})}
+                {...(this._genTestProps() ? genTestProps(`textarea-${this._genTestProps()}`) : {})}
             >
                 {this.props.value}
             </TextInput>

--- a/react/components/atoms/textarea/textarea.js
+++ b/react/components/atoms/textarea/textarea.js
@@ -1,10 +1,11 @@
 import React, { PureComponent } from "react";
 import { StyleSheet, ViewPropTypes, TextInput } from "react-native";
 import PropTypes from "prop-types";
+import { mix } from "yonius";
 
-import { capitalize, baseStyles, genIdProps } from "../../../util";
+import { IdentifiableMixin, baseStyles, capitalize } from "../../../util";
 
-export class TextArea extends PureComponent {
+export class TextArea extends mix(PureComponent).with(IdentifiableMixin) {
     static get propTypes() {
         return {
             value: PropTypes.string,
@@ -75,7 +76,7 @@ export class TextArea extends PureComponent {
                 onChangeText={this.props.onValue}
                 onFocus={this.props.onFocus}
                 onBlur={this.props.onBlur}
-                {...genIdProps(this.props.idPrefix, "textarea")}
+                {...this.id("textarea")}
             >
                 {this.props.value}
             </TextInput>

--- a/react/components/atoms/textarea/textarea.js
+++ b/react/components/atoms/textarea/textarea.js
@@ -18,8 +18,7 @@ export class TextArea extends PureComponent {
             onBlur: PropTypes.func,
             color: PropTypes.string,
             variant: PropTypes.string,
-            style: ViewPropTypes.style,
-            testId: PropTypes.string
+            style: ViewPropTypes.style
         };
     }
 
@@ -36,8 +35,7 @@ export class TextArea extends PureComponent {
             onBlur: () => {},
             color: undefined,
             variant: undefined,
-            style: {},
-            testId: undefined
+            style: {}
         };
     }
 
@@ -66,8 +64,6 @@ export class TextArea extends PureComponent {
         ];
     };
 
-    _testId = () => this.props.testId || this.props.placeholder;
-
     render() {
         return (
             <TextInput
@@ -79,7 +75,7 @@ export class TextArea extends PureComponent {
                 onChangeText={this.props.onValue}
                 onFocus={this.props.onFocus}
                 onBlur={this.props.onBlur}
-                {...(this._genTestProps() ? genTestProps(`textarea-${this._genTestProps()}`) : {})}
+                {...genTestProps(this.props.testPrefix, "textarea")}
             >
                 {this.props.value}
             </TextInput>

--- a/react/components/atoms/textarea/textarea.js
+++ b/react/components/atoms/textarea/textarea.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import { StyleSheet, ViewPropTypes, TextInput } from "react-native";
 import PropTypes from "prop-types";
 
-import { capitalize, baseStyles, genTestProps } from "../../../util";
+import { capitalize, baseStyles, genIdProps } from "../../../util";
 
 export class TextArea extends PureComponent {
     static get propTypes() {
@@ -75,7 +75,7 @@ export class TextArea extends PureComponent {
                 onChangeText={this.props.onValue}
                 onFocus={this.props.onFocus}
                 onBlur={this.props.onBlur}
-                {...genTestProps(this.props.testPrefix, "textarea")}
+                {...genIdProps(this.props.idPrefix, "textarea")}
             >
                 {this.props.value}
             </TextInput>

--- a/react/components/atoms/textarea/textarea.js
+++ b/react/components/atoms/textarea/textarea.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import { StyleSheet, ViewPropTypes, TextInput } from "react-native";
 import PropTypes from "prop-types";
 
-import { capitalize, baseStyles } from "../../../util";
+import { capitalize, baseStyles, testId } from "../../../util";
 
 export class TextArea extends PureComponent {
     static get propTypes() {
@@ -18,7 +18,8 @@ export class TextArea extends PureComponent {
             onBlur: PropTypes.func,
             color: PropTypes.string,
             variant: PropTypes.string,
-            style: ViewPropTypes.style
+            style: ViewPropTypes.style,
+            testId: PropTypes.string
         };
     }
 
@@ -35,7 +36,8 @@ export class TextArea extends PureComponent {
             onBlur: () => {},
             color: undefined,
             variant: undefined,
-            style: {}
+            style: {},
+            testId: undefined
         };
     }
 
@@ -64,6 +66,8 @@ export class TextArea extends PureComponent {
         ];
     };
 
+    _testId = () => this.props.testId || this.props.placeholder;
+
     render() {
         return (
             <TextInput
@@ -75,6 +79,7 @@ export class TextArea extends PureComponent {
                 onChangeText={this.props.onValue}
                 onFocus={this.props.onFocus}
                 onBlur={this.props.onBlur}
+                {...this._testId() ? testId(`textarea-${this._testId()}`) : {}}
             >
                 {this.props.value}
             </TextInput>

--- a/react/components/atoms/textarea/textarea.js
+++ b/react/components/atoms/textarea/textarea.js
@@ -79,7 +79,7 @@ export class TextArea extends PureComponent {
                 onChangeText={this.props.onValue}
                 onFocus={this.props.onFocus}
                 onBlur={this.props.onBlur}
-                {...this._testId() ? testId(`textarea-${this._testId()}`) : {}}
+                {...(this._testId() ? testId(`textarea-${this._testId()}`) : {})}
             >
                 {this.props.value}
             </TextInput>

--- a/react/components/molecules/header/header.js
+++ b/react/components/molecules/header/header.js
@@ -2,12 +2,13 @@ import React, { PureComponent } from "react";
 import { Platform, StyleSheet, Text } from "react-native";
 import PropTypes from "prop-types";
 import SafeAreaView from "react-native-safe-area-view";
+import { mix } from "yonius";
 
-import { baseStyles, genIdProps } from "../../../util";
+import { IdentifiableMixin, baseStyles } from "../../../util";
 
 import { Icon, Touchable } from "../../atoms";
 
-export class Header extends PureComponent {
+export class Header extends mix(PureComponent).with(IdentifiableMixin) {
     static get propTypes() {
         return {
             title: PropTypes.string,
@@ -63,12 +64,12 @@ export class Header extends PureComponent {
                             height={24}
                             strokeWidth={2}
                             color={"#1d2631"}
-                            idPrefix={`${this.props.idPrefix}-button-header-left`}
+                            {...this.id("header-button-left")}
                         />
                     </Touchable>
                 ) : null}
                 {this.props.title ? (
-                    <Text style={styles.title} {...genIdProps("text-header")}>
+                    <Text style={styles.title} {...this.id("header-text")}>
                         {this.props.title}
                     </Text>
                 ) : null}
@@ -86,7 +87,7 @@ export class Header extends PureComponent {
                             width={24}
                             height={30}
                             strokeWidth={2}
-                            idPrefix={`${this.props.idPrefix}-button-header-right`}
+                            {...this.id("header-button-right")}
                         />
                     </Touchable>
                 ) : null}

--- a/react/components/molecules/header/header.js
+++ b/react/components/molecules/header/header.js
@@ -23,7 +23,9 @@ export class Header extends PureComponent {
                 bottom: PropTypes.number.isRequired
             }),
             onButtonLeftPress: PropTypes.func,
-            onButtonRightPress: PropTypes.func
+            onButtonRightPress: PropTypes.func,
+            buttonLeftTestId: PropTypes.string,
+            buttonRightTestId: PropTypes.string
         };
     }
 
@@ -37,7 +39,9 @@ export class Header extends PureComponent {
             buttonRightVisible: false,
             hitSlop: { top: 20, left: 20, right: 20, bottom: 20 },
             onButtonLeftPress: undefined,
-            onButtonRightPress: undefined
+            onButtonRightPress: undefined,
+            buttonLeftTestId: undefined,
+            buttonRightTestId: undefined
         };
     }
 
@@ -63,7 +67,7 @@ export class Header extends PureComponent {
                             height={24}
                             strokeWidth={2}
                             color={"#1d2631"}
-                            testId={"button-header-left"}
+                            testId={this.props.buttonLeftTestId || "button-header-left"}
                         />
                     </Touchable>
                 ) : null}
@@ -86,7 +90,7 @@ export class Header extends PureComponent {
                             width={24}
                             height={30}
                             strokeWidth={2}
-                            testId={"button-header-right"}
+                            testId={this.props.buttonRightTestId || "button-header-right"}
                         />
                     </Touchable>
                 ) : null}

--- a/react/components/molecules/header/header.js
+++ b/react/components/molecules/header/header.js
@@ -3,7 +3,7 @@ import { Platform, StyleSheet, Text } from "react-native";
 import PropTypes from "prop-types";
 import SafeAreaView from "react-native-safe-area-view";
 
-import { baseStyles, genTestProps } from "../../../util";
+import { baseStyles, genIdProps } from "../../../util";
 
 import { Icon, Touchable } from "../../atoms";
 
@@ -63,12 +63,12 @@ export class Header extends PureComponent {
                             height={24}
                             strokeWidth={2}
                             color={"#1d2631"}
-                            testPrefix={`${this.props.testPrefix}-button-header-left`}
+                            idPrefix={`${this.props.idPrefix}-button-header-left`}
                         />
                     </Touchable>
                 ) : null}
                 {this.props.title ? (
-                    <Text style={styles.title} {...genTestProps("text-header")}>
+                    <Text style={styles.title} {...genIdProps("text-header")}>
                         {this.props.title}
                     </Text>
                 ) : null}
@@ -86,7 +86,7 @@ export class Header extends PureComponent {
                             width={24}
                             height={30}
                             strokeWidth={2}
-                            testPrefix={`${this.props.testPrefix}-button-header-right`}
+                            idPrefix={`${this.props.idPrefix}-button-header-right`}
                         />
                     </Touchable>
                 ) : null}

--- a/react/components/molecules/header/header.js
+++ b/react/components/molecules/header/header.js
@@ -3,7 +3,7 @@ import { Platform, StyleSheet, Text } from "react-native";
 import PropTypes from "prop-types";
 import SafeAreaView from "react-native-safe-area-view";
 
-import { baseStyles } from "../../../util";
+import { baseStyles, testId } from "../../../util";
 
 import { Icon, Touchable } from "../../atoms";
 
@@ -63,10 +63,11 @@ export class Header extends PureComponent {
                             height={24}
                             strokeWidth={2}
                             color={"#1d2631"}
+                            testId={"button-header-left"}
                         />
                     </Touchable>
                 ) : null}
-                {this.props.title ? <Text style={styles.title}>{this.props.title}</Text> : null}
+                {this.props.title ? <Text style={styles.title} {...testId("text-header")}>{this.props.title}</Text> : null}
                 {this.props.buttonRightVisible && this.props.buttonRightIcon ? (
                     <Touchable
                         hitSlop={this.props.hitSlop}
@@ -81,6 +82,7 @@ export class Header extends PureComponent {
                             width={24}
                             height={30}
                             strokeWidth={2}
+                            testId={"button-header-right"}
                         />
                     </Touchable>
                 ) : null}

--- a/react/components/molecules/header/header.js
+++ b/react/components/molecules/header/header.js
@@ -3,7 +3,7 @@ import { Platform, StyleSheet, Text } from "react-native";
 import PropTypes from "prop-types";
 import SafeAreaView from "react-native-safe-area-view";
 
-import { baseStyles, testId } from "../../../util";
+import { baseStyles, genTestProps } from "../../../util";
 
 import { Icon, Touchable } from "../../atoms";
 
@@ -72,7 +72,7 @@ export class Header extends PureComponent {
                     </Touchable>
                 ) : null}
                 {this.props.title ? (
-                    <Text style={styles.title} {...testId("text-header")}>
+                    <Text style={styles.title} {...genTestProps("text-header")}>
                         {this.props.title}
                     </Text>
                 ) : null}

--- a/react/components/molecules/header/header.js
+++ b/react/components/molecules/header/header.js
@@ -23,9 +23,7 @@ export class Header extends PureComponent {
                 bottom: PropTypes.number.isRequired
             }),
             onButtonLeftPress: PropTypes.func,
-            onButtonRightPress: PropTypes.func,
-            buttonLeftTestId: PropTypes.string,
-            buttonRightTestId: PropTypes.string
+            onButtonRightPress: PropTypes.func
         };
     }
 
@@ -39,9 +37,7 @@ export class Header extends PureComponent {
             buttonRightVisible: false,
             hitSlop: { top: 20, left: 20, right: 20, bottom: 20 },
             onButtonLeftPress: undefined,
-            onButtonRightPress: undefined,
-            buttonLeftTestId: undefined,
-            buttonRightTestId: undefined
+            onButtonRightPress: undefined
         };
     }
 
@@ -67,7 +63,7 @@ export class Header extends PureComponent {
                             height={24}
                             strokeWidth={2}
                             color={"#1d2631"}
-                            testId={this.props.buttonLeftTestId || "button-header-left"}
+                            testPrefix={`${this.props.testPrefix}-button-header-left`}
                         />
                     </Touchable>
                 ) : null}
@@ -90,7 +86,7 @@ export class Header extends PureComponent {
                             width={24}
                             height={30}
                             strokeWidth={2}
-                            testId={this.props.buttonRightTestId || "button-header-right"}
+                            testPrefix={`${this.props.testPrefix}-button-header-right`}
                         />
                     </Touchable>
                 ) : null}

--- a/react/components/molecules/header/header.js
+++ b/react/components/molecules/header/header.js
@@ -67,7 +67,11 @@ export class Header extends PureComponent {
                         />
                     </Touchable>
                 ) : null}
-                {this.props.title ? <Text style={styles.title} {...testId("text-header")}>{this.props.title}</Text> : null}
+                {this.props.title ? (
+                    <Text style={styles.title} {...testId("text-header")}>
+                        {this.props.title}
+                    </Text>
+                ) : null}
                 {this.props.buttonRightVisible && this.props.buttonRightIcon ? (
                     <Touchable
                         hitSlop={this.props.hitSlop}

--- a/react/components/molecules/key-value/key-value.js
+++ b/react/components/molecules/key-value/key-value.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import { StyleSheet, View, Text, Platform, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 
-import { baseStyles, genTestProps } from "../../../util";
+import { baseStyles, genIdProps } from "../../../util";
 
 import { ButtonIcon, Touchable } from "../../atoms";
 
@@ -69,11 +69,11 @@ export class KeyValue extends PureComponent {
             >
                 <View
                     style={styles.textContainer}
-                    {...genTestProps(this.props.testPrefix, "key-value")}
+                    {...genIdProps(this.props.idPrefix, "key-value")}
                 >
                     <Text
                         style={this._keyStyle()}
-                        {...genTestProps(this.props.testPrefix, "key-value-key")}
+                        {...genIdProps(this.props.idPrefix, "key-value-key")}
                     >
                         {this.props._key}
                     </Text>
@@ -82,7 +82,7 @@ export class KeyValue extends PureComponent {
                     ) : (
                         <Text
                             style={this._valueStyle()}
-                            {...genTestProps(this.props.testPrefix, "key-value-value")}
+                            {...genIdProps(this.props.idPrefix, "key-value-value")}
                         >
                             {this.props.value}
                         </Text>

--- a/react/components/molecules/key-value/key-value.js
+++ b/react/components/molecules/key-value/key-value.js
@@ -24,8 +24,7 @@ export class KeyValue extends PureComponent {
             onPress: PropTypes.func,
             onButtonIconPress: PropTypes.func,
             onLongPress: PropTypes.func,
-            style: ViewPropTypes.style,
-            testId: PropTypes.string
+            style: ViewPropTypes.style
         };
     }
 
@@ -44,8 +43,7 @@ export class KeyValue extends PureComponent {
             onPress: () => {},
             onButtonIconPress: () => {},
             onLongPress: () => {},
-            style: {},
-            testId: undefined
+            style: {}
         };
     }
 
@@ -69,13 +67,10 @@ export class KeyValue extends PureComponent {
                 onPress={this.props.onPress}
                 onLongPress={this.props.onLongPress}
             >
-                <View
-                    style={styles.textContainer}
-                    {...genTestProps(this.props.testId || `key-value-${this.props._key}`)}
-                >
+                <View style={styles.textContainer} {...genTestProps("key-value", this.testSuffix)}>
                     <Text
                         style={this._keyStyle()}
-                        {...genTestProps(this.props.testId || `key-value-key-${this.props._key}`)}
+                        {...genTestProps("key-value-key", this.testSuffix)}
                     >
                         {this.props._key}
                     </Text>
@@ -84,9 +79,7 @@ export class KeyValue extends PureComponent {
                     ) : (
                         <Text
                             style={this._valueStyle()}
-                            {...genTestProps(
-                                this.props.testId || `key-value-value-${this.props._key}`
-                            )}
+                            {...genTestProps("key-value-value", this.testSuffix)}
                         >
                             {this.props.value}
                         </Text>

--- a/react/components/molecules/key-value/key-value.js
+++ b/react/components/molecules/key-value/key-value.js
@@ -1,12 +1,13 @@
 import React, { PureComponent } from "react";
 import { StyleSheet, View, Text, Platform, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
+import { mix } from "yonius";
 
-import { baseStyles, genIdProps } from "../../../util";
+import { IdentifiableMixin, baseStyles } from "../../../util";
 
 import { ButtonIcon, Touchable } from "../../atoms";
 
-export class KeyValue extends PureComponent {
+export class KeyValue extends mix(PureComponent).with(IdentifiableMixin) {
     static get propTypes() {
         return {
             _key: PropTypes.string.isRequired,
@@ -67,23 +68,14 @@ export class KeyValue extends PureComponent {
                 onPress={this.props.onPress}
                 onLongPress={this.props.onLongPress}
             >
-                <View
-                    style={styles.textContainer}
-                    {...genIdProps(this.props.idPrefix, "key-value")}
-                >
-                    <Text
-                        style={this._keyStyle()}
-                        {...genIdProps(this.props.idPrefix, "key-value-key")}
-                    >
+                <View style={styles.textContainer} {...this.id("key-value")}>
+                    <Text style={this._keyStyle()} {...this.id("key-value-key")}>
                         {this.props._key}
                     </Text>
                     {this.props.children ? (
                         this.props.children
                     ) : (
-                        <Text
-                            style={this._valueStyle()}
-                            {...genIdProps(this.props.idPrefix, "key-value-value")}
-                        >
+                        <Text style={this._valueStyle()} {...this.id("key-value-value")}>
                             {this.props.value}
                         </Text>
                     )}

--- a/react/components/molecules/key-value/key-value.js
+++ b/react/components/molecules/key-value/key-value.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import { StyleSheet, View, Text, Platform, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 
-import { baseStyles } from "../../../util";
+import { baseStyles, testId } from "../../../util";
 
 import { ButtonIcon, Touchable } from "../../atoms";
 
@@ -24,7 +24,8 @@ export class KeyValue extends PureComponent {
             onPress: PropTypes.func,
             onButtonIconPress: PropTypes.func,
             onLongPress: PropTypes.func,
-            style: ViewPropTypes.style
+            style: ViewPropTypes.style,
+            testId: PropTypes.string
         };
     }
 
@@ -43,7 +44,8 @@ export class KeyValue extends PureComponent {
             onPress: () => {},
             onButtonIconPress: () => {},
             onLongPress: () => {},
-            style: {}
+            style: {},
+            testId: undefined
         };
     }
 
@@ -67,12 +69,12 @@ export class KeyValue extends PureComponent {
                 onPress={this.props.onPress}
                 onLongPress={this.props.onLongPress}
             >
-                <View style={styles.textContainer}>
-                    <Text style={this._keyStyle()}>{this.props._key}</Text>
+                <View style={styles.textContainer} {...testId(this.props.testId || `key-value-${this.props._key}`)}>
+                    <Text style={this._keyStyle()} {...testId(this.props.testId || `key-value-key-${this.props._key}`)}>{this.props._key}</Text>
                     {this.props.children ? (
                         this.props.children
                     ) : (
-                        <Text style={this._valueStyle()}>{this.props.value}</Text>
+                        <Text style={this._valueStyle()} {...testId(this.props.testId || `key-value-value-${this.props._key}`)}>{this.props.value}</Text>
                     )}
                 </View>
                 {this.props.icon ? (

--- a/react/components/molecules/key-value/key-value.js
+++ b/react/components/molecules/key-value/key-value.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import { StyleSheet, View, Text, Platform, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 
-import { baseStyles, testId } from "../../../util";
+import { baseStyles, genTestProps } from "../../../util";
 
 import { ButtonIcon, Touchable } from "../../atoms";
 
@@ -71,11 +71,11 @@ export class KeyValue extends PureComponent {
             >
                 <View
                     style={styles.textContainer}
-                    {...testId(this.props.testId || `key-value-${this.props._key}`)}
+                    {...genTestProps(this.props.testId || `key-value-${this.props._key}`)}
                 >
                     <Text
                         style={this._keyStyle()}
-                        {...testId(this.props.testId || `key-value-key-${this.props._key}`)}
+                        {...genTestProps(this.props.testId || `key-value-key-${this.props._key}`)}
                     >
                         {this.props._key}
                     </Text>
@@ -84,7 +84,9 @@ export class KeyValue extends PureComponent {
                     ) : (
                         <Text
                             style={this._valueStyle()}
-                            {...testId(this.props.testId || `key-value-value-${this.props._key}`)}
+                            {...genTestProps(
+                                this.props.testId || `key-value-value-${this.props._key}`
+                            )}
                         >
                             {this.props.value}
                         </Text>

--- a/react/components/molecules/key-value/key-value.js
+++ b/react/components/molecules/key-value/key-value.js
@@ -67,7 +67,10 @@ export class KeyValue extends PureComponent {
                 onPress={this.props.onPress}
                 onLongPress={this.props.onLongPress}
             >
-                <View style={styles.textContainer} {...genTestProps(this.props.testPrefix, "key-value")}>
+                <View
+                    style={styles.textContainer}
+                    {...genTestProps(this.props.testPrefix, "key-value")}
+                >
                     <Text
                         style={this._keyStyle()}
                         {...genTestProps(this.props.testPrefix, "key-value-key")}

--- a/react/components/molecules/key-value/key-value.js
+++ b/react/components/molecules/key-value/key-value.js
@@ -67,10 +67,10 @@ export class KeyValue extends PureComponent {
                 onPress={this.props.onPress}
                 onLongPress={this.props.onLongPress}
             >
-                <View style={styles.textContainer} {...genTestProps("key-value", this.testSuffix)}>
+                <View style={styles.textContainer} {...genTestProps(this.props.testPrefix, "key-value")}>
                     <Text
                         style={this._keyStyle()}
-                        {...genTestProps("key-value-key", this.testSuffix)}
+                        {...genTestProps(this.props.testPrefix, "key-value-key")}
                     >
                         {this.props._key}
                     </Text>
@@ -79,7 +79,7 @@ export class KeyValue extends PureComponent {
                     ) : (
                         <Text
                             style={this._valueStyle()}
-                            {...genTestProps("key-value-value", this.testSuffix)}
+                            {...genTestProps(this.props.testPrefix, "key-value-value")}
                         >
                             {this.props.value}
                         </Text>

--- a/react/components/molecules/key-value/key-value.js
+++ b/react/components/molecules/key-value/key-value.js
@@ -69,12 +69,25 @@ export class KeyValue extends PureComponent {
                 onPress={this.props.onPress}
                 onLongPress={this.props.onLongPress}
             >
-                <View style={styles.textContainer} {...testId(this.props.testId || `key-value-${this.props._key}`)}>
-                    <Text style={this._keyStyle()} {...testId(this.props.testId || `key-value-key-${this.props._key}`)}>{this.props._key}</Text>
+                <View
+                    style={styles.textContainer}
+                    {...testId(this.props.testId || `key-value-${this.props._key}`)}
+                >
+                    <Text
+                        style={this._keyStyle()}
+                        {...testId(this.props.testId || `key-value-key-${this.props._key}`)}
+                    >
+                        {this.props._key}
+                    </Text>
                     {this.props.children ? (
                         this.props.children
                     ) : (
-                        <Text style={this._valueStyle()} {...testId(this.props.testId || `key-value-value-${this.props._key}`)}>{this.props.value}</Text>
+                        <Text
+                            style={this._valueStyle()}
+                            {...testId(this.props.testId || `key-value-value-${this.props._key}`)}
+                        >
+                            {this.props.value}
+                        </Text>
                     )}
                 </View>
                 {this.props.icon ? (

--- a/react/components/molecules/keyboard-numeric/keyboard-numeric.js
+++ b/react/components/molecules/keyboard-numeric/keyboard-numeric.js
@@ -103,7 +103,7 @@ export class KeyboardNumeric extends PureComponent {
                     />
                     <ButtonKeyboard
                         style={styles.buttonKeyboard}
-                        testPrefix={"button-keyboard-backspace"}
+                        idPrefix={"button-keyboard-backspace"}
                         icon="chevron-left"
                         variant={"clean"}
                         value={"delete"}

--- a/react/components/molecules/keyboard-numeric/keyboard-numeric.js
+++ b/react/components/molecules/keyboard-numeric/keyboard-numeric.js
@@ -103,6 +103,7 @@ export class KeyboardNumeric extends PureComponent {
                     />
                     <ButtonKeyboard
                         style={styles.buttonKeyboard}
+                        testId={"button-keyboard-backspace"}
                         icon="chevron-left"
                         variant={"clean"}
                         value={"delete"}

--- a/react/components/molecules/keyboard-numeric/keyboard-numeric.js
+++ b/react/components/molecules/keyboard-numeric/keyboard-numeric.js
@@ -1,11 +1,12 @@
 import React, { PureComponent } from "react";
 import { StyleSheet, View } from "react-native";
 import PropTypes from "prop-types";
+import { mix } from "yonius";
 
 import { ButtonKeyboard } from "../../atoms";
-import { isTabletSize } from "../../../util";
+import { IdentifiableMixin, isTabletSize } from "../../../util";
 
-export class KeyboardNumeric extends PureComponent {
+export class KeyboardNumeric extends mix(PureComponent).with(IdentifiableMixin) {
     static get propTypes() {
         return {
             onKeyPress: PropTypes.func,
@@ -103,7 +104,7 @@ export class KeyboardNumeric extends PureComponent {
                     />
                     <ButtonKeyboard
                         style={styles.buttonKeyboard}
-                        idPrefix={"button-keyboard-backspace"}
+                        {...this.id("keyboard-button-backspace")}
                         icon="chevron-left"
                         variant={"clean"}
                         value={"delete"}

--- a/react/components/molecules/keyboard-numeric/keyboard-numeric.js
+++ b/react/components/molecules/keyboard-numeric/keyboard-numeric.js
@@ -103,7 +103,7 @@ export class KeyboardNumeric extends PureComponent {
                     />
                     <ButtonKeyboard
                         style={styles.buttonKeyboard}
-                        testId={"button-keyboard-backspace"}
+                        testPrefix={"button-keyboard-backspace"}
                         icon="chevron-left"
                         variant={"clean"}
                         value={"delete"}

--- a/react/util/utils.js
+++ b/react/util/utils.js
@@ -75,6 +75,7 @@ export const isImage = function (fileName) {
  * to a React component allowing it to be properly selected.
  */
 export const genIdProps = function (idPrefix, idSuffix) {
+    console.log(this);
     const id = _genId(idPrefix, idSuffix);
     return Platform.OS === "android"
         ? { accessible: true, accessibilityLabel: id, idPrefix: id }

--- a/react/util/utils.js
+++ b/react/util/utils.js
@@ -66,15 +66,18 @@ export const isImage = function (fileName) {
  * Generates a properties object from the base test identifier of a component
  * taking into consideration the current execution context.
  *
- * @param {String} id The identifier of the element as a plain string.
+ * @param {String} idPrefix The prefix of the identifier for the element as a plain string.
+ * @param {String} idSuffix The suffix of the identifier for the element as a plain string.
  * @param {Boolean} normalizeId If the identifier should be normalized according to
  * a series of standards (eg: dash instead of space).
  * @returns {Object} The resulting properties object that can be used to add properties
  * to a React component allowing it to be properly tested.
  */
-export const genTestProps = function (id, normalizeId = true) {
-    if (!id) return {};
-    const normalized = normalizeId ? id.trim().toLowerCase().split(" ").join("-") : id;
+export const genTestProps = function (idPrefix, idSuffix, normalizeId = true) {
+    if (!idPrefix || !idSuffix) return {};
+    idPrefix = normalizeId ? idPrefix.trim().toLowerCase().split(" ").join("-") : idPrefix;
+    idSuffix = normalizeId ? idSuffix.trim().toLowerCase().split(" ").join("-") : idSuffix;
+    const normalized = `${idPrefix}-${idSuffix}`;
     return Platform.OS === "android"
         ? { accessible: true, accessibilityLabel: normalized }
         : { testID: normalized };

--- a/react/util/utils.js
+++ b/react/util/utils.js
@@ -1,3 +1,5 @@
+import { Platform } from "react-native";
+
 export const dateString = function (timestamp, { separator = "/", year = true } = {}) {
     const date = new Date(timestamp * 1000);
     const day = date.getDate() < 10 ? `0${date.getDate()}` : date.getDate();
@@ -58,4 +60,12 @@ export const capitalize = function (value) {
 export const isImage = function (fileName) {
     const regex = /\.(jpg|jpeg|png|gif)$/i;
     return regex.test(fileName);
+};
+
+export const testId = function (id, normalizeId = true) {
+    if (!id) return {};
+    const normalized = normalizeId ? id.trim().toLowerCase().split(" ").join("-") : id;
+    return Platform.OS === "android" ?
+        { accessible: true, accessibilityLabel: normalized } :
+        { testID: normalized }
 };

--- a/react/util/utils.js
+++ b/react/util/utils.js
@@ -62,36 +62,44 @@ export const isImage = function (fileName) {
     return regex.test(fileName);
 };
 
-/**
- * Generates a properties object from the base identifier of a component
- * taking into consideration the current execution context.
- *
- * The resulting structure can be used to access the component from external
- * tools (eg: test automation).
- *
- * @param {String} idPrefix The prefix of the identifier for the element as a plain string.
- * @param {String} idSuffix The suffix of the identifier for the element as a plain string.
- * @returns {Object} The resulting properties object that can be used to add properties
- * to a React component allowing it to be properly selected.
- */
-export const genIdProps = function (idPrefix, idSuffix) {
-    console.log(this);
-    const id = _genId(idPrefix, idSuffix);
-    return Platform.OS === "android"
-        ? { accessible: true, accessibilityLabel: id, idPrefix: id }
-        : { testID: id, idPrefix: id };
-};
+export const IdentifiableMixin = superclass =>
+    class extends superclass {
+        /**
+         * @see {@link genIdProps}
+         */
+        id(id) {
+            return this.genIdProps(id);
+        }
 
-/**
- * Generates an identifier from a list of identifiers, sanitizing
- * its internal structure from illegal characters.
- *
- * @param  {...String} ids The sequence of identifiers to generate
- * identifier from.
- */
-const _genId = function (...ids) {
-    return ids
-        .filter(Boolean)
-        .map(id => id.trim().toLowerCase().split(" ").join("-"))
-        .join("-");
-};
+        /**
+         * Generates a properties object from the base identifier of a component
+         * taking into consideration the current execution context.
+         *
+         * The resulting structure can be used to access the component from external
+         * tools (eg: test automation).
+         *
+         * @param {String} idSuffix The suffix of the identifier for the element as a plain string.
+         * @returns {Object} The resulting properties object that can be used to add properties
+         * to a React component allowing it to be properly selected.
+         */
+        genIdProps(idSuffix) {
+            const id = this._genId(this.props.idPrefix, idSuffix);
+            return Platform.OS === "android"
+                ? { accessible: true, accessibilityLabel: id, idPrefix: id }
+                : { testID: id, idPrefix: id };
+        }
+
+        /**
+         * Generates an identifier from a list of identifiers, sanitizing
+         * its internal structure from illegal characters.
+         *
+         * @param  {...String} ids The sequence of identifiers to generate
+         * identifier from.
+         */
+        _genId(...ids) {
+            return ids
+                .filter(Boolean)
+                .map(id => id.trim().toLowerCase().split(" ").join("-"))
+                .join("-");
+        }
+    };

--- a/react/util/utils.js
+++ b/react/util/utils.js
@@ -62,9 +62,17 @@ export const isImage = function (fileName) {
     return regex.test(fileName);
 };
 
-export const genTestId = function(...ids) {
-    return ids.filter(Boolean).map(id => id.trim().toLowerCase().split(" ").join("-")).join("-");
-}
+/**
+ * Generates a test ID from a list of identifiers.
+ *
+ * @param  {...string} ids The list of identifiers to generate the test ID from.
+ */
+export const genTestId = function (...ids) {
+    return ids
+        .filter(Boolean)
+        .map(id => id.trim().toLowerCase().split(" ").join("-"))
+        .join("-");
+};
 
 /**
  * Generates a properties object from the base test identifier of a component
@@ -72,8 +80,6 @@ export const genTestId = function(...ids) {
  *
  * @param {String} idPrefix The prefix of the identifier for the element as a plain string.
  * @param {String} idSuffix The suffix of the identifier for the element as a plain string.
- * @param {Boolean} normalizeId If the identifier should be normalized according to
- * a series of standards (eg: dash instead of space).
  * @returns {Object} The resulting properties object that can be used to add properties
  * to a React component allowing it to be properly tested.
  */
@@ -81,5 +87,5 @@ export const genTestProps = function (idPrefix, idSuffix) {
     const id = genTestId(idPrefix, idSuffix);
     return Platform.OS === "android"
         ? { accessible: true, accessibilityLabel: id }
-        : { testID: normalized };
+        : { testID: id };
 };

--- a/react/util/utils.js
+++ b/react/util/utils.js
@@ -65,7 +65,7 @@ export const isImage = function (fileName) {
 export const testId = function (id, normalizeId = true) {
     if (!id) return {};
     const normalized = normalizeId ? id.trim().toLowerCase().split(" ").join("-") : id;
-    return Platform.OS === "android" ?
-        { accessible: true, accessibilityLabel: normalized } :
-        { testID: normalized }
+    return Platform.OS === "android"
+        ? { accessible: true, accessibilityLabel: normalized }
+        : { testID: normalized };
 };

--- a/react/util/utils.js
+++ b/react/util/utils.js
@@ -62,7 +62,17 @@ export const isImage = function (fileName) {
     return regex.test(fileName);
 };
 
-export const testId = function (id, normalizeId = true) {
+/**
+ * Generates a properties object from the base test identifier of a component
+ * taking into consideration the current execution context.
+ *
+ * @param {String} id The identifier of the element as a plain string.
+ * @param {Boolean} normalizeId If the identifier should be normalized according to
+ * a series of standards (eg: dash instead of space).
+ * @returns {Object} The resulting properties object that can be used to add properties
+ * to a React component allowing it to be properly tested.
+ */
+export const genTestProps = function (id, normalizeId = true) {
     if (!id) return {};
     const normalized = normalizeId ? id.trim().toLowerCase().split(" ").join("-") : id;
     return Platform.OS === "android"

--- a/react/util/utils.js
+++ b/react/util/utils.js
@@ -63,29 +63,34 @@ export const isImage = function (fileName) {
 };
 
 /**
- * Generates a test ID from a list of identifiers.
- *
- * @param  {...string} ids The list of identifiers to generate the test ID from.
- */
-export const genTestId = function (...ids) {
-    return ids
-        .filter(Boolean)
-        .map(id => id.trim().toLowerCase().split(" ").join("-"))
-        .join("-");
-};
-
-/**
- * Generates a properties object from the base test identifier of a component
+ * Generates a properties object from the base identifier of a component
  * taking into consideration the current execution context.
+ *
+ * The resulting structure can be used to access the component from external
+ * tools (eg: test automation).
  *
  * @param {String} idPrefix The prefix of the identifier for the element as a plain string.
  * @param {String} idSuffix The suffix of the identifier for the element as a plain string.
  * @returns {Object} The resulting properties object that can be used to add properties
- * to a React component allowing it to be properly tested.
+ * to a React component allowing it to be properly selected.
  */
-export const genTestProps = function (idPrefix, idSuffix) {
-    const id = genTestId(idPrefix, idSuffix);
+export const genIdProps = function (idPrefix, idSuffix) {
+    const id = _genId(idPrefix, idSuffix);
     return Platform.OS === "android"
-        ? { accessible: true, accessibilityLabel: id }
-        : { testID: id };
+        ? { accessible: true, accessibilityLabel: id, idPrefix: id }
+        : { testID: id, idPrefix: id };
+};
+
+/**
+ * Generates an identifier from a list of identifiers, sanitizing
+ * its internal structure from illegal characters.
+ *
+ * @param  {...String} ids The sequence of identifiers to generate
+ * identifier from.
+ */
+const _genId = function (...ids) {
+    return ids
+        .filter(Boolean)
+        .map(id => id.trim().toLowerCase().split(" ").join("-"))
+        .join("-");
 };

--- a/react/util/utils.js
+++ b/react/util/utils.js
@@ -62,6 +62,10 @@ export const isImage = function (fileName) {
     return regex.test(fileName);
 };
 
+export const genTestId = function(...ids) {
+    return ids.filter(Boolean).map(id => id.trim().toLowerCase().split(" ").join("-")).join("-");
+}
+
 /**
  * Generates a properties object from the base test identifier of a component
  * taking into consideration the current execution context.
@@ -73,12 +77,9 @@ export const isImage = function (fileName) {
  * @returns {Object} The resulting properties object that can be used to add properties
  * to a React component allowing it to be properly tested.
  */
-export const genTestProps = function (idPrefix, idSuffix, normalizeId = true) {
-    if (!idPrefix || !idSuffix) return {};
-    idPrefix = normalizeId ? idPrefix.trim().toLowerCase().split(" ").join("-") : idPrefix;
-    idSuffix = normalizeId ? idSuffix.trim().toLowerCase().split(" ").join("-") : idSuffix;
-    const normalized = `${idPrefix}-${idSuffix}`;
+export const genTestProps = function (idPrefix, idSuffix) {
+    const id = genTestId(idPrefix, idSuffix);
     return Platform.OS === "android"
-        ? { accessible: true, accessibilityLabel: normalized }
+        ? { accessible: true, accessibilityLabel: id }
         : { testID: normalized };
 };


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/197 |
| Decisions | Add test IDs to allow for faster and easier automated testing (IDs rather than XPath). For Android, the way Appium recommends to do so is through accessibility labels. |
