### PR TITLE
feat: add scroll behaviour to tabs text

### DIFF
--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -103,7 +103,7 @@ export class TabsText extends PureComponent {
             x: event.nativeEvent.layout.x,
             width: event.nativeEvent.layout.width
         };
-        if (index === this.props.tabs.length - 1) this.setOverflow();
+        if (index === this.props.tabs.length - 1) this._setOverflow();
         this._updateBar();
     };
 

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -74,7 +74,7 @@ export class TabsText extends PureComponent {
 
     _setOverflow = () => {
         const tabsTextWidth = Object.values(this.tabLayouts)
-            .map(value => value.width)
+            .map(tabLayout => tabLayout.width)
             .reduce(this._summation);
         this.overflows = tabsTextWidth > Dimensions.get("window").width;
     };

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -75,7 +75,7 @@ export class TabsText extends PureComponent {
     _setOverflow = () => {
         const tabsTextWidth = Object.values(this.tabLayouts)
             .map(value => value.width)
-            .reduce(this._sum);
+            .reduce(this._summation);
         this.overflows = tabsTextWidth > Dimensions.get("window").width;
     };
 

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -93,7 +93,7 @@ export class TabsText extends PureComponent {
         this._updateBar();
     };
 
-    _scrollToTabIfOverflows(tabSelectedIndex) {
+    _scrollTo(index) {
         const deviceWidth = this.props.parentWidth || Dimensions.get("window").width;
         const tabLayout = this.tabLayouts[tabSelectedIndex];
         const overflowRight = tabLayout.x + tabLayout.width > deviceWidth;

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -47,6 +47,7 @@ export class TabsText extends PureComponent {
         };
         this.tabLayouts = {};
         this.XScroll = 0;
+        this.overflows = false;
     }
 
     onTabPress = tabSelectedIndex => {
@@ -69,6 +70,13 @@ export class TabsText extends PureComponent {
     onScroll = event => {
         const XScroll = event.nativeEvent.contentOffset.x;
         this.XScroll = XScroll;
+    };
+
+    setOverflow = () => {
+        const tabsTextWidth = Object.values(this.tabLayouts)
+            .map(value => value.width)
+            .reduce(this._sum);
+        this.overflows = tabsTextWidth > Dimensions.get("window").width;
     };
 
     _updateBar = () => {
@@ -95,6 +103,7 @@ export class TabsText extends PureComponent {
             x: event.nativeEvent.layout.x,
             width: event.nativeEvent.layout.width
         };
+        if (index === this.props.tabs.length - 1) this.setOverflow();
         this._updateBar();
     };
 
@@ -129,12 +138,17 @@ export class TabsText extends PureComponent {
         ));
     }
 
+    _sum = (previousValue, currentValue) => {
+        return previousValue + currentValue;
+    };
+
     render() {
         return (
             <ScrollView
                 contentContainerStyle={{ flexGrow: 1 }}
                 style={this._style()}
                 horizontal={true}
+                scrollEnabled={this.overflows}
                 showsHorizontalScrollIndicator={false}
                 onScroll={this.onScroll}
                 ref={this.scrollRef}

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -62,7 +62,7 @@ export class TabsText extends PureComponent {
 
     onScroll = event => {
         const XScroll = event.nativeEvent.contentOffset.x;
-        this.XScroll = XScroll;
+        this.scroll = scroll;
     };
 
     _updateBar = () => {

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -138,7 +138,7 @@ export class TabsText extends PureComponent {
         ));
     }
 
-    _sum = (previousValue, currentValue) => {
+    _summation = (previousValue, currentValue) => {
         return previousValue + currentValue;
     };
 

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -72,7 +72,7 @@ export class TabsText extends PureComponent {
         this.XScroll = XScroll;
     };
 
-    setOverflow = () => {
+    _setOverflow = () => {
         const tabsTextWidth = Object.values(this.tabLayouts)
             .map(value => value.width)
             .reduce(this._sum);

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -57,30 +57,12 @@ export class TabsText extends PureComponent {
             this._updateBar();
             this.props.onTabChange(this.state.tabSelected);
         });
-        const deviceWidth = this.props.parentWidth || Dimensions.get("window").width;
-        const tabLayout = this.tabLayouts[tabSelectedIndex];
-        const overflowRight = tabLayout.x + tabLayout.width > deviceWidth;
-        const overflowLeft = this.XScroll > tabLayout.x;
-        const tabOverflows = overflowRight || overflowLeft;
-
-        if (tabOverflows) {
-            const X = overflowRight ? tabLayout.x + tabLayout.width : tabLayout.x;
-            this.scrollRef.current.scrollTo({ x: X });
-        }
+        this._scrollToTabIfOverflows(tabSelectedIndex);
     };
 
     onScroll = event => {
         const XScroll = event.nativeEvent.contentOffset.x;
         this.XScroll = XScroll;
-    };
-
-    _setOverflow = () => {
-        const tabsTextWidth = Object.values(this.tabLayouts)
-            .map(tabLayout => tabLayout.width)
-            .reduce((previousValue, currentValue) => {
-                return previousValue + currentValue;
-            });
-        this.overflows = tabsTextWidth > Dimensions.get("window").width;
     };
 
     _updateBar = () => {
@@ -107,9 +89,22 @@ export class TabsText extends PureComponent {
             x: event.nativeEvent.layout.x,
             width: event.nativeEvent.layout.width
         };
-        if (index === this.props.tabs.length - 1) this._setOverflow();
+
         this._updateBar();
     };
+
+    _scrollToTabIfOverflows(tabSelectedIndex) {
+        const deviceWidth = this.props.parentWidth || Dimensions.get("window").width;
+        const tabLayout = this.tabLayouts[tabSelectedIndex];
+        const overflowRight = tabLayout.x + tabLayout.width > deviceWidth;
+        const overflowLeft = this.XScroll > tabLayout.x;
+        const tabOverflows = overflowRight || overflowLeft;
+
+        if (tabOverflows) {
+            const X = overflowRight ? tabLayout.x + tabLayout.width : tabLayout.x;
+            this.scrollRef.current.scrollTo({ x: X });
+        }
+    }
 
     _style() {
         return [
@@ -148,7 +143,7 @@ export class TabsText extends PureComponent {
                 contentContainerStyle={{ flexGrow: 1 }}
                 style={this._style()}
                 horizontal={true}
-                scrollEnabled={this.overflows}
+                alwaysBounceHorizontal={false}
                 showsHorizontalScrollIndicator={false}
                 onScroll={this.onScroll}
                 ref={this.scrollRef}

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -57,7 +57,7 @@ export class TabsText extends PureComponent {
             this._updateBar();
             this.props.onTabChange(this.state.tabSelected);
         });
-        this._scrollToTabIfOverflows(tabSelectedIndex);
+        this._scrollTo(tabSelectedIndex);
     };
 
     onScroll = event => {

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -97,7 +97,7 @@ export class TabsText extends PureComponent {
         const deviceWidth = this.props.parentWidth || Dimensions.get("window").width;
         const tabLayout = this.tabLayouts[index];
         const overflowRight = tabLayout.x + tabLayout.width > deviceWidth;
-        const overflowLeft = this.XScroll > tabLayout.x;
+        const overflowLeft = this.scroll > tabLayout.x;
         const tabOverflows = overflowRight || overflowLeft;
 
         if (tabOverflows) {

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -19,6 +19,7 @@ export class TabsText extends PureComponent {
             tabsColor: PropTypes.string,
             tabSelected: PropTypes.number,
             variant: PropTypes.string,
+            parentWidth: PropTypes.number,
             onTabChange: PropTypes.func.isRequired,
             style: ViewPropTypes.style
         };
@@ -31,6 +32,7 @@ export class TabsText extends PureComponent {
             tabsColor: "#24425a",
             tabSelected: 0,
             variant: undefined,
+            parentWidth: undefined,
             style: {}
         };
     }
@@ -55,7 +57,7 @@ export class TabsText extends PureComponent {
             this._updateBar();
             this.props.onTabChange(this.state.tabSelected);
         });
-        const deviceWidth = Dimensions.get("window").width;
+        const deviceWidth = this.props.parentWidth || Dimensions.get("window").width;
         const tabLayout = this.tabLayouts[tabSelectedIndex];
         const overflowRight = tabLayout.x + tabLayout.width > deviceWidth;
         const overflowLeft = this.XScroll > tabLayout.x;

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -49,7 +49,6 @@ export class TabsText extends PureComponent {
         };
         this.tabLayouts = {};
         this.scroll = 0;
-        this.overflows = false;
     }
 
     onTabPress = tabSelectedIndex => {

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -59,10 +59,10 @@ export class TabsText extends PureComponent {
         const tabLayout = this.tabLayouts[tabSelectedIndex];
         const overflowRight = tabLayout.x + tabLayout.width > deviceWidth;
         const overflowLeft = this.XScroll > tabLayout.x;
-        const tabOverflows = overFlowRight || overFlowLeft;
+        const tabOverflows = overflowRight || overflowLeft;
 
         if (tabOverflows) {
-            const X = overFlowRight ? tabLayout.x + tabLayout.width : tabLayout.x;
+            const X = overflowRight ? tabLayout.x + tabLayout.width : tabLayout.x;
             this.scrollRef.current.scrollTo({ x: X });
         }
     };
@@ -75,7 +75,9 @@ export class TabsText extends PureComponent {
     _setOverflow = () => {
         const tabsTextWidth = Object.values(this.tabLayouts)
             .map(tabLayout => tabLayout.width)
-            .reduce(this._summation);
+            .reduce((previousValue, currentValue) => {
+                return previousValue + currentValue;
+            });
         this.overflows = tabsTextWidth > Dimensions.get("window").width;
     };
 
@@ -137,10 +139,6 @@ export class TabsText extends PureComponent {
             </View>
         ));
     }
-
-    _summation = (previousValue, currentValue) => {
-        return previousValue + currentValue;
-    };
 
     render() {
         return (

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -101,7 +101,7 @@ export class TabsText extends PureComponent {
         const tabOverflows = overflowRight || overflowLeft;
 
         if (tabOverflows) {
-            const X = overflowRight ? tabLayout.x + tabLayout.width : tabLayout.x;
+            const scroll = overflowRight ? tabLayout.x + tabLayout.width : tabLayout.x;
             this.scrollRef.current.scrollTo({ x: X });
         }
     }

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -1,13 +1,5 @@
 import React, { PureComponent } from "react";
-import {
-    StyleSheet,
-    ViewPropTypes,
-    View,
-    ScrollView,
-    Alert,
-    Dimensions,
-    useRef
-} from "react-native";
+import { StyleSheet, ViewPropTypes, View, ScrollView, Dimensions } from "react-native";
 import PropTypes from "prop-types";
 
 import { capitalize } from "../../../util";

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -46,7 +46,7 @@ export class TabsText extends PureComponent {
             animatedBarOffset: undefined
         };
         this.tabLayouts = {};
-        this.XScroll = 0;
+        this.scroll = 0;
         this.overflows = false;
     }
 

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -39,7 +39,6 @@ export class TabsText extends PureComponent {
 
     constructor(props) {
         super(props);
-        this.scrollRef = React.createRef();
 
         this.state = {
             tabs: props.tabs,
@@ -49,6 +48,7 @@ export class TabsText extends PureComponent {
         };
         this.tabLayouts = {};
         this.scroll = 0;
+        this.scrollRef = React.createRef();
     }
 
     onTabPress = tabSelectedIndex => {
@@ -88,7 +88,6 @@ export class TabsText extends PureComponent {
             x: event.nativeEvent.layout.x,
             width: event.nativeEvent.layout.width
         };
-
         this._updateBar();
     };
 

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -57,8 +57,8 @@ export class TabsText extends PureComponent {
         });
         const deviceWidth = Dimensions.get("window").width;
         const tabLayout = this.tabLayouts[tabSelectedIndex];
-        const overFlowRight = tabLayout.x + tabLayout.width > deviceWidth;
-        const overFlowLeft = this.XScroll > tabLayout.x;
+        const overflowRight = tabLayout.x + tabLayout.width > deviceWidth;
+        const overflowLeft = this.XScroll > tabLayout.x;
         const tabOverflows = overFlowRight || overFlowLeft;
 
         if (tabOverflows) {

--- a/react/components/molecules/tabs-text/tabs-text.js
+++ b/react/components/molecules/tabs-text/tabs-text.js
@@ -61,7 +61,7 @@ export class TabsText extends PureComponent {
     };
 
     onScroll = event => {
-        const XScroll = event.nativeEvent.contentOffset.x;
+        const scroll = event.nativeEvent.contentOffset.x;
         this.scroll = scroll;
     };
 
@@ -95,14 +95,14 @@ export class TabsText extends PureComponent {
 
     _scrollTo(index) {
         const deviceWidth = this.props.parentWidth || Dimensions.get("window").width;
-        const tabLayout = this.tabLayouts[tabSelectedIndex];
+        const tabLayout = this.tabLayouts[index];
         const overflowRight = tabLayout.x + tabLayout.width > deviceWidth;
         const overflowLeft = this.XScroll > tabLayout.x;
         const tabOverflows = overflowRight || overflowLeft;
 
         if (tabOverflows) {
             const scroll = overflowRight ? tabLayout.x + tabLayout.width : tabLayout.x;
-            this.scrollRef.current.scrollTo({ x: X });
+            this.scrollRef.current.scrollTo({ x: scroll });
         }
     }
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Related issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/223 |
| Decisions | Use ScrollView as the parent component, Scroll behaviour only if overflow exists |
| Animated GIF | ![CNe5PaCj49 (2)](https://user-images.githubusercontent.com/8842023/112026945-9f29b800-8b2e-11eb-8024-461f081e2b94.gif) |
