### PR TITLE
Fix buttonTabText component with 'compact' variant

### DIFF
--- a/react/components/atoms/button-tab-text/button-tab-text.js
+++ b/react/components/atoms/button-tab-text/button-tab-text.js
@@ -80,6 +80,7 @@ const styles = StyleSheet.create({
         justifyContent: "center"
     },
     buttonTabTextCompact: {
+        flex: 0,
         paddingVertical: 9,
         paddingHorizontal: 16
     },


### PR DESCRIPTION
| - | - |
| --- | --- |
| Descripton | Regression provoked by:  https://github.com/ripe-tech/ripe-components-react-native/pull/167 |
| Animated GIF | ![y9cD2gtewU](https://user-images.githubusercontent.com/8842023/115721911-63c11a00-a376-11eb-8173-956d7280b162.gif)|
