### PR TITLE
fix: normalizeImages function handling of images coming from camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* `normalizeImages` function handling of images coming from camera
 
 ## [0.4.0] - 2021-04-07
 

--- a/react/util/ui-utils.js
+++ b/react/util/ui-utils.js
@@ -60,7 +60,7 @@ export const pickDocuments = async function (options = {}) {
 };
 
 const normalizeImages = function (images) {
-    return images?.assets
+    return images.assets
         ? images.assets.map(image => ({
               uri: image.uri,
               name: image.fileName || getUriBasename(image.uri),

--- a/react/util/ui-utils.js
+++ b/react/util/ui-utils.js
@@ -60,14 +60,23 @@ export const pickDocuments = async function (options = {}) {
 };
 
 const normalizeImages = function (images) {
-    return images.assets.map(image => ({
-        uri: image.uri,
-        name: image.fileName || getUriBasename(image.uri),
-        type: image.type,
-        size: image.fileSize,
-        width: image.width,
-        height: image.height
-    }));
+    return images?.assets
+        ? images.assets.map(image => ({
+              uri: image.uri,
+              name: image.fileName || getUriBasename(image.uri),
+              type: image.type,
+              size: image.fileSize,
+              width: image.width,
+              height: image.height
+          }))
+        : {
+              uri: images.uri,
+              name: images.fileName || getUriBasename(images.uri),
+              type: images.type,
+              size: images.fileSize,
+              width: images.width,
+              height: images.height
+          };
 };
 
 export const pickImageCamera = async function ({


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/252  |
| Decisions | Picked when testing attach from the camera with a real device...Handle the different(https://www.npmjs.com/package/react-native-image-picker#the-response-object)) response object that comes from picking from the camera. This is not well specified in the docs |
