### PR TITLE
#263 Chat scroll animation as optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Multiple files selection with image picker
 * Date input component
 * Switcher component
+* Added animateScrollToEnd prop to chat
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Multiple files selection with image picker
 * Date input component
 * Switcher component
-* Added animateScrollToEnd prop to chat
+* Added `animateScrollBottom` prop to chat
 
 ### Changed
 

--- a/react/components/organisms/chat/chat.js
+++ b/react/components/organisms/chat/chat.js
@@ -26,7 +26,7 @@ export class Chat extends PureComponent {
                     )
                 })
             ),
-            animateScrollToEnd: PropTypes.bool,
+            animateScrollBottom: PropTypes.bool,
             onNewMessage: PropTypes.func,
             style: ViewPropTypes.style
         };
@@ -37,7 +37,7 @@ export class Chat extends PureComponent {
             avatarUrl: undefined,
             username: undefined,
             messages: [],
-            animateScrollToEnd: true,
+            animateScrollBottom: true,
             onNewMessage: () => {},
             style: {}
         };
@@ -61,7 +61,7 @@ export class Chat extends PureComponent {
     };
 
     scrollToEnd = () => {
-        this.scrollViewComponent.scrollToEnd({ animated: this.props.animateScrollToEnd });
+        this.scrollViewComponent.scrollToEnd({ animated: this.props.animateScrollBottom });
     };
 
     getInputValue = () => (this.input ? this.input.state.value || null : null);

--- a/react/components/organisms/chat/chat.js
+++ b/react/components/organisms/chat/chat.js
@@ -26,7 +26,7 @@ export class Chat extends PureComponent {
                     )
                 })
             ),
-            scrollAnimated: PropTypes.bool,
+            animateScrollToEnd: PropTypes.bool,
             onNewMessage: PropTypes.func,
             style: ViewPropTypes.style
         };
@@ -37,7 +37,7 @@ export class Chat extends PureComponent {
             avatarUrl: undefined,
             username: undefined,
             messages: [],
-            scrollAnimated: true,
+            animateScrollToEnd: true,
             onNewMessage: () => {},
             style: {}
         };
@@ -61,7 +61,7 @@ export class Chat extends PureComponent {
     };
 
     scrollToEnd = () => {
-        this.scrollViewComponent.scrollToEnd({ animated: this.props.scrollAnimated });
+        this.scrollViewComponent.scrollToEnd({ animated: this.props.animateScrollToEnd });
     };
 
     getInputValue = () => (this.input ? this.input.state.value || null : null);

--- a/react/components/organisms/chat/chat.js
+++ b/react/components/organisms/chat/chat.js
@@ -26,6 +26,7 @@ export class Chat extends PureComponent {
                     )
                 })
             ),
+            scrollAnimated: PropTypes.bool,
             onNewMessage: PropTypes.func,
             style: ViewPropTypes.style
         };
@@ -36,6 +37,7 @@ export class Chat extends PureComponent {
             avatarUrl: undefined,
             username: undefined,
             messages: [],
+            scrollAnimated: true,
             onNewMessage: () => {},
             style: {}
         };
@@ -59,7 +61,7 @@ export class Chat extends PureComponent {
     };
 
     scrollToEnd = () => {
-        this.scrollViewComponent.scrollToEnd({ animated: true });
+        this.scrollViewComponent.scrollToEnd({ animated: this.props.scrollAnimated });
     };
 
     getInputValue = () => (this.input ? this.input.state.value || null : null);


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/pull/267#issuecomment-866939952 |
| Dependencies | -- |
| Decisions | Add `animateScrollToEnd` props that dictates if the chat scroll is/isn't animated |

**Animated:**

https://user-images.githubusercontent.com/22588915/123624942-1d20ed80-d807-11eb-87fb-2b20f2c0f7bb.mov

**Not animated:**

https://user-images.githubusercontent.com/22588915/123624938-1c885700-d807-11eb-83e0-656d7211a77d.mov
