### PR TITLE
#263 Add onScroll and onScrollBottom props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Multiple files selection with image picker
 * Date input component
 * Switcher component
+* onScroll and onScrollBottom props in chat component
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Multiple files selection with image picker
 * Date input component
 * Switcher component
-* `onScroll` and `onScrollBottom` props in chat component - []
+* `onScroll` and `onScrollBottom` props in chat component
 * Radio group component
 
 ### Changed

--- a/react/components/organisms/chat/chat.js
+++ b/react/components/organisms/chat/chat.js
@@ -27,6 +27,8 @@ export class Chat extends PureComponent {
                 })
             ),
             onNewMessage: PropTypes.func,
+            onScrollBottom: PropTypes.func,
+            onScroll: PropTypes.func,
             style: ViewPropTypes.style
         };
     }
@@ -37,6 +39,8 @@ export class Chat extends PureComponent {
             username: undefined,
             messages: [],
             onNewMessage: () => {},
+            onScrollBottom: () => {},
+            onScroll: event => {},
             style: {}
         };
     }
@@ -63,6 +67,16 @@ export class Chat extends PureComponent {
     };
 
     getInputValue = () => (this.input ? this.input.state.value || null : null);
+
+    onScroll = event => {
+        this.props.onScroll(event);
+        if (
+            event.nativeEvent.layoutMeasurement.height + event.nativeEvent.contentOffset.y >=
+            event.nativeEvent.contentSize.height
+        ) {
+            this.props.onScrollBottom();
+        }
+    };
 
     async _onNewMessage(message) {
         this.setState({ sendingMessage: true }, () => {
@@ -123,6 +137,7 @@ export class Chat extends PureComponent {
                     style={styles.chatMessagesContainer}
                     ref={ref => (this.scrollViewComponent = ref)}
                     onContentSizeChange={this.scrollToEnd}
+                    onScroll={this.onScroll}
                 >
                     <View style={styles.chatMessagesContent}>
                         {this.props.messages.map((message, index) => {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/pull/267#discussion_r659795083 |
| Dependencies | -- |
| Decisions | • Add ScrollView `onScroll` event as a prop <br>• Add `onScrollBottom` prop that is triggered when the scroll reaches the bottom  |
