### PR TITLE
Add key value improvement and clipboard util method

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "svgo": "^2.3.0"
     },
     "peerDependencies": {
+        "@react-native-community/clipboard": "^1.5.1",
         "@react-native-picker/picker": "^1.16.1",
         "buffer": "^6.0.3",
         "react": "^17.0.1",

--- a/react/components/molecules/key-value/key-value.js
+++ b/react/components/molecules/key-value/key-value.js
@@ -65,8 +65,8 @@ export class KeyValue extends mix(PureComponent).with(IdentifiableMixin) {
             <Touchable
                 style={this._style()}
                 disabled={!this.props.pressable}
-                onPress={this.props.onPress}
-                onLongPress={this.props.onLongPress}
+                onPress={() => this.props.onPress(this.props._key, this.props.value)}
+                onLongPress={() => this.props.onLongPress(this.props._key, this.props.value)}
             >
                 <View style={styles.textContainer} {...this.id("key-value")}>
                     <Text style={this._keyStyle()} {...this.id("key-value-key")}>

--- a/react/util/ui-utils.js
+++ b/react/util/ui-utils.js
@@ -146,12 +146,10 @@ export const notify = function (message) {
         : Alert.alert(message);
 };
 
-export const toClipboard = function (value, notification = true) {
+export const toClipboard = function (value, options = { notification: true, vibrate: true }) {
     Clipboard.setString(`${value}`);
-    if (!notification) return;
-
-    notify("Copied to clipboard");
-    Vibration.vibrate();
+    if (options.notification) notify("Copied to clipboard");
+    if (options.vibrate) Vibration.vibrate();
 };
 
 export const isTabletSize = function () {

--- a/react/util/ui-utils.js
+++ b/react/util/ui-utils.js
@@ -148,6 +148,7 @@ export const notify = function (message) {
 
 export const toClipboard = function (value, notification = true) {
     Clipboard.setString(`${value}`);
+
     if (notification) {
         notify("Copied to clipboard");
         Vibration.vibrate();

--- a/react/util/ui-utils.js
+++ b/react/util/ui-utils.js
@@ -148,11 +148,10 @@ export const notify = function (message) {
 
 export const toClipboard = function (value, notification = true) {
     Clipboard.setString(`${value}`);
+    if (!notification) return;
 
-    if (notification) {
-        notify("Copied to clipboard");
-        Vibration.vibrate();
-    }
+    notify("Copied to clipboard");
+    Vibration.vibrate();
 };
 
 export const isTabletSize = function () {

--- a/react/util/ui-utils.js
+++ b/react/util/ui-utils.js
@@ -4,11 +4,13 @@ import {
     Linking,
     PermissionsAndroid,
     Platform,
+    Vibration,
     ToastAndroid
 } from "react-native";
 import DeviceInfo from "react-native-device-info";
 import DocumentPicker from "react-native-document-picker";
 import { launchCamera, launchImageLibrary } from "react-native-image-picker";
+import Clipboard from "@react-native-community/clipboard";
 
 import { getUriBasename } from "./utils";
 
@@ -142,6 +144,14 @@ export const notify = function (message) {
     Platform.OS === "android"
         ? ToastAndroid.show(message, ToastAndroid.SHORT)
         : Alert.alert(message);
+};
+
+export const toClipboard = function (value, notification = true) {
+    Clipboard.setString(`${value}`);
+    if (notification) {
+        notify("Copied to clipboard");
+        Vibration.vibrate();
+    }
 };
 
 export const isTabletSize = function () {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | - Add `toClipboard` based on the [ripe-components-vue's toClipboard](https://github.com/ripe-tech/ripe-components-vue/blob/c2abe5555da16bf0c3901f7e33136d43f6a4dec0/vue/mixins/clipboard.js#L3)<br> - The util `toClipboard` method will clean for duplicated code and imports for clipboard pages in ripe-robin implementation and others in the future. <br> - Passing `_key` and `value` args in `onPress` and `onLongPress` callbacks - this will simplify the process specially when having several key-value component elements and wanting to perform different action that depend on internal values -- please check the implementation of this in ripe-robin where instead of having to create 14 new methods for 14 different key-values, we can now handle everything in one method. |
