### PR TITLE
fix: onRichTextInputPhotoAdded function in chat component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * `normalizeImages` function handling of images coming from camera
-* `onRichTextInputPhotoAdded` function in chat component
+* `onRichTextInputPhotoAdded` function in chat component as from the time the `react-native-image-picker` was bumped to v4.0, there is no need to force an array in attachment property
 
 ## [0.4.0] - 2021-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * `normalizeImages` function handling of images coming from camera
+* `onRichTextInputPhotoAdded` function in chat component
 
 ## [0.4.0] - 2021-04-07
 

--- a/react/components/organisms/chat/chat.js
+++ b/react/components/organisms/chat/chat.js
@@ -89,7 +89,7 @@ export class Chat extends PureComponent {
             username: this.props.username,
             message: this.getInputValue(),
             date: Date.now(),
-            attachments: [source]
+            attachments: source
         };
         await this._onNewMessage(message);
     };


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | This was originated by the breaking change made in https://github.com/ripe-tech/ripe-robin-revamp/pull/260. Now the library will always return an array as result, wich voids the necessity of normalising the response within an array |
| Animated GIF | Before https://user-images.githubusercontent.com/8842023/124160394-1eb31580-da94-11eb-9afd-8c0f920d2b97.MP4 <br> After https://user-images.githubusercontent.com/8842023/124161114-ed871500-da94-11eb-9d21-c8b57aadd2f3.mp4|
