### PR TITLE
Fix story name format

### DIFF
--- a/react/components/atoms/avatar/avatar.stories.js
+++ b/react/components/atoms/avatar/avatar.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, number } from "@storybook/addon-knobs";
 
 import { Avatar } from "./avatar";
 
-storiesOf("Components/Atoms/Avatar", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Avatar", () => {
         const size = number("Size", -1);

--- a/react/components/atoms/badge/badge.stories.js
+++ b/react/components/atoms/badge/badge.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, number, text } from "@storybook/addon-knobs";
 
 import { Badge } from "./badge";
 
-storiesOf("Components/Atoms/Badge", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Badge", () => {
         const _text = text("Text", "");

--- a/react/components/atoms/bar-animated/bar-animated.stories.js
+++ b/react/components/atoms/bar-animated/bar-animated.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, number, text } from "@storybook/addon-knobs";
 
 import { BarAnimated } from "./bar-animated";
 
-storiesOf("Components/Atoms/Bar Animated", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Bar Animated", () => {
         const offset = number("Offset", 100);

--- a/react/components/atoms/button-icon/button-icon.stories.js
+++ b/react/components/atoms/button-icon/button-icon.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, boolean, number, select, text } from "@storybook/addon-knobs
 
 import { ButtonIcon } from "./button-icon";
 
-storiesOf("Components/Atoms/Button Icon", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Button Icon", () => {
         const icon = select(

--- a/react/components/atoms/button-keyboard/button-keyboard.stories.js
+++ b/react/components/atoms/button-keyboard/button-keyboard.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, select, text } from "@storybook/addon-knobs";
 
 import { ButtonKeyboard } from "./button-keyboard";
 
-storiesOf("Components/Atoms/Button Keyboard", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Button Keyboard", () => {
         const _text = text("Button Text", "8");

--- a/react/components/atoms/button-tab-text/button-tab-text.stories.js
+++ b/react/components/atoms/button-tab-text/button-tab-text.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, boolean, select, text } from "@storybook/addon-knobs";
 
 import { ButtonTabText } from "./button-tab-text";
 
-storiesOf("Components/Atoms/Button Tab Text", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Button Tab Text", () => {
         const _text = text("Text", "User");

--- a/react/components/atoms/button-tab/button-tab.stories.js
+++ b/react/components/atoms/button-tab/button-tab.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, boolean, number, select, text } from "@storybook/addon-knobs
 
 import { ButtonTab } from "./button-tab";
 
-storiesOf("Components/Atoms/Button Tab", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Button Tab", () => {
         const _text = text("Text", "User");

--- a/react/components/atoms/button/button.stories.js
+++ b/react/components/atoms/button/button.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, boolean, number, select, text } from "@storybook/addon-knobs
 
 import { Button } from "./button";
 
-storiesOf("Components/Atoms/Button", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Button", () => {
         const _text = text("Button Text", "Use Platforme ID");

--- a/react/components/atoms/checkbox/checkbox.stories.js
+++ b/react/components/atoms/checkbox/checkbox.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, boolean, number, select, text } from "@storybook/addon-knobs
 
 import { Checkbox } from "./checkbox";
 
-storiesOf("Components/Atoms/Checkbox", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Checkbox", () => {
         const label = text("Label", "Label");

--- a/react/components/atoms/container-draggable/container-draggable.stories.js
+++ b/react/components/atoms/container-draggable/container-draggable.stories.js
@@ -6,7 +6,7 @@ import { Button, StyleSheet, Text, View } from "react-native";
 import { ContainerDraggable } from "./container-draggable";
 import { ContainerOpenable } from "../container-openable";
 
-storiesOf("Components/Atoms/Container Draggable", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Container Draggable", () => {
         const ref = React.createRef();

--- a/react/components/atoms/container-openable/container-openable.stories.js
+++ b/react/components/atoms/container-openable/container-openable.stories.js
@@ -5,7 +5,7 @@ import { Button, StyleSheet, Text, View } from "react-native";
 
 import { ContainerOpenable } from "./container-openable";
 
-storiesOf("Components/Atoms/Container Openable", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Container Openable", () => {
         const ref = React.createRef();

--- a/react/components/atoms/container-swipeable/container-swipeable.stories.js
+++ b/react/components/atoms/container-swipeable/container-swipeable.stories.js
@@ -8,7 +8,7 @@ import { Icon } from "../icon";
 
 import { ContainerSwipeable } from "./container-swipeable";
 
-storiesOf("Components/Atoms/Container Swipeable", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Container Swipeable", () => {
         const swipeThreshold = number("Trigger Action Threshold Value", 0.25);

--- a/react/components/atoms/fade-view/fade-view.stories.js
+++ b/react/components/atoms/fade-view/fade-view.stories.js
@@ -5,7 +5,7 @@ import { withKnobs, number } from "@storybook/addon-knobs";
 
 import { FadeView } from "./fade-view";
 
-storiesOf("Components/Atoms/Fade View", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Fade View", () => {
         const duration = number("Duration", 500);

--- a/react/components/atoms/icon/icon.stories.js
+++ b/react/components/atoms/icon/icon.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, number, select, text } from "@storybook/addon-knobs";
 
 import { Icon } from "./icon";
 
-storiesOf("Components/Atoms/Icon", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Icon", () => {
         const icon = select(

--- a/react/components/atoms/lightbox/lightbox.stories.js
+++ b/react/components/atoms/lightbox/lightbox.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, number, select, text } from "@storybook/addon-knobs";
 
 import { Lightbox } from "./lightbox";
 
-storiesOf("Components/Atoms/Lightbox", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Lightbox", () => {
         const uri = text(

--- a/react/components/atoms/link/link.stories.js
+++ b/react/components/atoms/link/link.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, text as knobText } from "@storybook/addon-knobs";
 
 import { Link } from "./link";
 
-storiesOf("Components/Atoms/Link", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Link", () => {
         const text = knobText("Text", "Platforme Link");

--- a/react/components/atoms/progress-bar/progress-bar.stories.js
+++ b/react/components/atoms/progress-bar/progress-bar.stories.js
@@ -98,7 +98,7 @@ class Wrapper extends PureComponent {
     }
 }
 
-storiesOf("Components/Atoms/Progress Bar", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Progress Bar", () => {
         const steps = number("Steps", 3);

--- a/react/components/atoms/radio/radio.stories.js
+++ b/react/components/atoms/radio/radio.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, boolean, number, select, text } from "@storybook/addon-knobs
 
 import { Radio } from "./radio";
 
-storiesOf("Components/Atoms/Radio", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Radio", () => {
         const label = text("Label", "Label");

--- a/react/components/atoms/switcher/switcher.stories.js
+++ b/react/components/atoms/switcher/switcher.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, boolean, number, select, text } from "@storybook/addon-knobs
 
 import { Switcher } from "./switcher";
 
-storiesOf("Components/Atoms/Switcher", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Switcher", () => {
         const checked = boolean("Checked", false);

--- a/react/components/atoms/tag/tag.stories.js
+++ b/react/components/atoms/tag/tag.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, number, select, text } from "@storybook/addon-knobs";
 
 import { Tag } from "./tag";
 
-storiesOf("Components/Atoms/Tag", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Tag", () => {
         const _text = text("Text", "Subscribed");

--- a/react/components/atoms/text/text.stories.js
+++ b/react/components/atoms/text/text.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, text } from "@storybook/addon-knobs";
 
 import { Text } from "./text";
 
-storiesOf("Components/Atoms/Text", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Text", () => {
         const value = text("Value", "Text example");

--- a/react/components/atoms/textarea/textarea.stories.js
+++ b/react/components/atoms/textarea/textarea.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, boolean, number, text } from "@storybook/addon-knobs";
 
 import { TextArea } from "./textarea";
 
-storiesOf("Components/Atoms/Textarea", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Textarea", () => {
         const onValue = value => {

--- a/react/components/atoms/touchable/touchable.stories.js
+++ b/react/components/atoms/touchable/touchable.stories.js
@@ -5,7 +5,7 @@ import { Alert, StyleSheet, Text } from "react-native";
 
 import { Touchable } from "./touchable";
 
-storiesOf("Components/Atoms/Touchable", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Touchable", () => {
         const activeOpacity = number("Active Opacity", 0.5);

--- a/react/components/molecules/button-toggle/button-toggle.stories.js
+++ b/react/components/molecules/button-toggle/button-toggle.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, boolean, select, text } from "@storybook/addon-knobs";
 
 import { ButtonToggle } from "./button-toggle";
 
-storiesOf("Components/Molecules/Button Toggle", module)
+storiesOf("Molecules", module)
     .addDecorator(withKnobs)
     .add("Button Toggle", () => {
         const _text = text("Text", undefined);

--- a/react/components/molecules/chat-message/chat-message.stories.js
+++ b/react/components/molecules/chat-message/chat-message.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, number, text } from "@storybook/addon-knobs";
 
 import { ChatMessage } from "./chat-message";
 
-storiesOf("Components/Molecules/Chat Message", module)
+storiesOf("Molecules", module)
     .addDecorator(withKnobs)
     .add("Chat Message", () => {
         const avatarUrl = text(

--- a/react/components/molecules/date-input/date-input.stories.js
+++ b/react/components/molecules/date-input/date-input.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, boolean, date, number, text } from "@storybook/addon-knobs";
 
 import { DateInput } from "./date-input";
 
-storiesOf("Components/Molecules/DateInput", module)
+storiesOf("Molecules", module)
     .addDecorator(withKnobs)
     .add("DateInput", () => {
         const value = date("Date", new Date());

--- a/react/components/molecules/header/header.stories.js
+++ b/react/components/molecules/header/header.stories.js
@@ -5,7 +5,7 @@ import { withKnobs, boolean, text } from "@storybook/addon-knobs";
 
 import { Header } from "./header";
 
-storiesOf("Components/Molecules/Header", module)
+storiesOf("Molecules", module)
     .addDecorator(withKnobs)
     .add("Header", () => {
         const title = text("Title", "Title");

--- a/react/components/molecules/item-notification/item-notification.stories.js
+++ b/react/components/molecules/item-notification/item-notification.stories.js
@@ -5,7 +5,7 @@ import { View } from "react-native";
 
 import { ItemNotification } from "./item-notification";
 
-storiesOf("Components/Molecules/Notification Item", module)
+storiesOf("Molecules", module)
     .addDecorator(withKnobs)
     .add("Notification Item", () => {
         const avatarUrl = text(

--- a/react/components/molecules/item/item.stories.js
+++ b/react/components/molecules/item/item.stories.js
@@ -5,7 +5,7 @@ import { withKnobs, boolean, number, select, text } from "@storybook/addon-knobs
 
 import { Item } from "./item";
 
-storiesOf("Components/Molecules/Item", module)
+storiesOf("Molecules", module)
     .addDecorator(withKnobs)
     .add("Item", () => {
         const header = boolean("Header", false);

--- a/react/components/molecules/key-value-placeholder/key-value-placeholder.stories.js
+++ b/react/components/molecules/key-value-placeholder/key-value-placeholder.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, number } from "@storybook/addon-knobs";
 
 import { KeyValuePlaceholder } from "./key-value-placeholder";
 
-storiesOf("Components/Atoms/Key Value Placeholder", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Key Value Placeholder", () => {
         const numberOfLines = number("Number of lines", 1);

--- a/react/components/molecules/key-value/key-value.stories.js
+++ b/react/components/molecules/key-value/key-value.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, number, select, text } from "@storybook/addon-knobs";
 
 import { KeyValue } from "./key-value";
 
-storiesOf("Components/Atoms/Key Value", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Key Value", () => {
         const key = text("Key", "Key");

--- a/react/components/molecules/key-values-placeholder/key-values-placeholder.stories.js
+++ b/react/components/molecules/key-values-placeholder/key-values-placeholder.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, number } from "@storybook/addon-knobs";
 
 import { KeyValuesPlaceholder } from "./key-values-placeholder";
 
-storiesOf("Components/Molecules/Key Values Placeholder", module)
+storiesOf("Molecules", module)
     .addDecorator(withKnobs)
     .add("Key Values Placeholder", () => {
         const numberOfItems = number("Number of items", 2);

--- a/react/components/molecules/key-values/key-values.stories.js
+++ b/react/components/molecules/key-values/key-values.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, boolean } from "@storybook/addon-knobs";
 
 import { KeyValues } from "./key-values";
 
-storiesOf("Components/Molecules/Key Values", module)
+storiesOf("Molecules", module)
     .addDecorator(withKnobs)
     .add("Key Values", () => {
         const items = [

--- a/react/components/molecules/keyboard-numeric/keyboard-numeric.stories.js
+++ b/react/components/molecules/keyboard-numeric/keyboard-numeric.stories.js
@@ -5,7 +5,7 @@ import { withKnobs } from "@storybook/addon-knobs";
 
 import { KeyboardNumeric } from "./keyboard-numeric";
 
-storiesOf("Components/Molecules/Numeric Keyboard", module)
+storiesOf("Molecules", module)
     .addDecorator(withKnobs)
     .add("Numeric Keyboard", () => {
         const onKeyPress = value => alert(value);

--- a/react/components/molecules/rich-textinput/rich-textinput.stories.js
+++ b/react/components/molecules/rich-textinput/rich-textinput.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, boolean, number, text } from "@storybook/addon-knobs";
 
 import { RichTextInput } from "./rich-textinput";
 
-storiesOf("Components/Atoms/RichTextInput", module)
+storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("RichTextInput", () => {
         const onPhotoAdded = source => {

--- a/react/components/molecules/section-view/section-view.stories.js
+++ b/react/components/molecules/section-view/section-view.stories.js
@@ -5,7 +5,7 @@ import { withKnobs, text } from "@storybook/addon-knobs";
 
 import { SectionView } from "./section-view";
 
-storiesOf("Components/Molecules/Section View", module)
+storiesOf("Molecules", module)
     .addDecorator(withKnobs)
     .add("Section View", () => {
         const _text = text("Text", "Label");

--- a/react/components/molecules/select/select.stories.js
+++ b/react/components/molecules/select/select.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, boolean, number, select, text } from "@storybook/addon-knobs
 
 import { Select } from "./select";
 
-storiesOf("Components/Molecules/Select", module)
+storiesOf("Molecules", module)
     .addDecorator(withKnobs)
     .add("Select", () => {
         const placeholder = text("Placeholder", "This is a placeholder text");

--- a/react/components/molecules/snackbar/snackbar.stories.js
+++ b/react/components/molecules/snackbar/snackbar.stories.js
@@ -5,7 +5,7 @@ import { withKnobs, number, text } from "@storybook/addon-knobs";
 
 import { Snackbar } from "./snackbar";
 
-storiesOf("Components/Molecules/Snackbar", module)
+storiesOf("Molecules", module)
     .addDecorator(withKnobs)
     .add("Snackbar", () => {
         const ref = React.createRef();

--- a/react/components/molecules/tabs-text/tabs-text.stories.js
+++ b/react/components/molecules/tabs-text/tabs-text.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, select } from "@storybook/addon-knobs";
 
 import { TabsText } from "./tabs-text";
 
-storiesOf("Components/Molecules/Tabs Text", module)
+storiesOf("Molecules", module)
     .addDecorator(withKnobs)
     .add("Tabs Text", () => {
         const tabs = [

--- a/react/components/molecules/tabs/tabs.stories.js
+++ b/react/components/molecules/tabs/tabs.stories.js
@@ -5,7 +5,7 @@ import { withKnobs, select } from "@storybook/addon-knobs";
 
 import { Tabs } from "./tabs";
 
-storiesOf("Components/Molecules/Tab", module)
+storiesOf("Molecules", module)
     .addDecorator(withKnobs)
     .add("Tab", () => {
         const selectedIndex = select(

--- a/react/components/molecules/toast-message/toast-message.stories.js
+++ b/react/components/molecules/toast-message/toast-message.stories.js
@@ -5,7 +5,7 @@ import { withKnobs, text } from "@storybook/addon-knobs";
 
 import { ToastMessage } from "./toast-message";
 
-storiesOf("Components/Molecules/Toast Message", module)
+storiesOf("Molecules", module)
     .addDecorator(withKnobs)
     .add("Toast Message", () => {
         const ref = React.createRef();

--- a/react/components/organisms/button-group/button-group.stories.js
+++ b/react/components/organisms/button-group/button-group.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, boolean, select } from "@storybook/addon-knobs";
 
 import { ButtonGroup } from "./button-group";
 
-storiesOf("Components/Organisms/Button Group", module)
+storiesOf("Organisms", module)
     .addDecorator(withKnobs)
     .add("Button Group", () => {
         const items = [

--- a/react/components/organisms/chat/chat.stories.js
+++ b/react/components/organisms/chat/chat.stories.js
@@ -5,7 +5,7 @@ import { withKnobs, text } from "@storybook/addon-knobs";
 
 import { Chat } from "./chat";
 
-storiesOf("Components/Organisms/Chat", module)
+storiesOf("Organisms", module)
     .addDecorator(withKnobs)
     .add("Chat", () => {
         const avatarUrl = text(

--- a/react/components/organisms/image-list/image-list.stories.js
+++ b/react/components/organisms/image-list/image-list.stories.js
@@ -4,7 +4,7 @@ import { withKnobs } from "@storybook/addon-knobs";
 
 import { ImageList } from "../image-list";
 
-storiesOf("Components/Organisms/Image List", module)
+storiesOf("Organisms", module)
     .addDecorator(withKnobs)
     .add("Image List", () => {
         const images = [


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Component story names have a bad structure in mobile |
| Decisions | Revert naming format to legacy format. |
| Animated GIFS | <h2> Before <br> ![simulator_screenshot_0D6AF9BC-DB7B-4BCA-88D1-01DCBDFF3176](https://user-images.githubusercontent.com/24736423/124262423-f2e26f00-db29-11eb-8839-fcd1e51641a6.png)  <h2> After <br> ![simulator_screenshot_CE5BE9E9-804E-4FE9-9AF3-A8A2345D0D6A](https://user-images.githubusercontent.com/24736423/124262287-c4649400-db29-11eb-9e4c-176f686ed753.png) |
