### PR TITLE
feat: do not show key values with no value

### DIFF
--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -43,7 +43,7 @@ export class KeyValues extends PureComponent {
     }
 
     _shouldShow = item => {
-        return Boolean(item.value) || (!item.value && this.props.showUnset);
+        return Boolean(item.value) || this.props.showUnset;
     };
 
     _style = () => {

--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -29,6 +29,7 @@ export class KeyValues extends PureComponent {
                 })
             ).isRequired,
             keyValueTwoColumns: PropTypes.bool,
+            showNotSet: PropTypes.bool,
             style: ViewPropTypes.style
         };
     }
@@ -36,9 +37,14 @@ export class KeyValues extends PureComponent {
     static get defaultProps() {
         return {
             keyValueTwoColumns: isTabletSize(),
+            showNotSet: true,
             style: {}
         };
     }
+
+    _shouldShow = item => {
+        return Boolean(item.value) || (!item.value && this.props.showNotSet);
+    };
 
     _style = () => {
         return [this.props.keyValueTwoColumns ? styles.keyValuesColumns : {}, this.props.style];
@@ -57,27 +63,29 @@ export class KeyValues extends PureComponent {
             <View style={this._style()}>
                 {this.props.items.map((item, index) => (
                     <View style={this._keyValueWrapperStyle()} key={item.key}>
-                        <KeyValue
-                            style={this._keyValueStyle(index)}
-                            key={item.key}
-                            _key={item.key}
-                            value={item.value}
-                            keyColor={item.keyColor}
-                            valueColor={item.valueColor}
-                            icon={item.icon}
-                            iconBackgroundColor={item.iconBackgroundColor}
-                            iconColor={item.iconColor}
-                            iconSize={item.iconSize}
-                            iconHeight={item.iconHeight}
-                            iconWidth={item.iconWidth}
-                            iconStrokeWidth={item.iconStrokeWidth}
-                            pressable={item.pressable}
-                            onPress={item.onPress}
-                            onButtonIconPress={item.onButtonIconPress}
-                            onLongPress={item.onLongPress}
-                        >
-                            {item.valueComponent}
-                        </KeyValue>
+                        {this._shouldShow(item) && (
+                            <KeyValue
+                                style={this._keyValueStyle(index)}
+                                key={item.key}
+                                _key={item.key}
+                                value={item.value}
+                                keyColor={item.keyColor}
+                                valueColor={item.valueColor}
+                                icon={item.icon}
+                                iconBackgroundColor={item.iconBackgroundColor}
+                                iconColor={item.iconColor}
+                                iconSize={item.iconSize}
+                                iconHeight={item.iconHeight}
+                                iconWidth={item.iconWidth}
+                                iconStrokeWidth={item.iconStrokeWidth}
+                                pressable={item.pressable}
+                                onPress={item.onPress}
+                                onButtonIconPress={item.onButtonIconPress}
+                                onLongPress={item.onLongPress}
+                            >
+                                {item.valueComponent}
+                            </KeyValue>
+                        )}
                     </View>
                 ))}
             </View>

--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -29,7 +29,7 @@ export class KeyValues extends PureComponent {
                 })
             ).isRequired,
             keyValueTwoColumns: PropTypes.bool,
-            showNotSet: PropTypes.bool,
+            showUnset: PropTypes.bool,
             style: ViewPropTypes.style
         };
     }
@@ -37,13 +37,13 @@ export class KeyValues extends PureComponent {
     static get defaultProps() {
         return {
             keyValueTwoColumns: isTabletSize(),
-            showNotSet: true,
+            showUnset: true,
             style: {}
         };
     }
 
     _shouldShow = item => {
-        return Boolean(item.value) || (!item.value && this.props.showNotSet);
+        return Boolean(item.value) || (!item.value && this.props.showUnset);
     };
 
     _style = () => {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Originated from ripe-id-mobile profile view screen, where we don't want to show key values were the value is not set. |
| Dependencies | -- |
| Decisions | Prop that allows not rendering key values whose values are not defined. |
| Animated GIF | -- |
