### PR TITLE
feat: avatar image update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `animateScrollBottom` prop to chat
 * `onScroll` and `onScrollBottom` props in chat component
 * Radio group component
+* Support for `Avatar`'s image change
 
 ### Changed
 

--- a/react/components/atoms/avatar/avatar.js
+++ b/react/components/atoms/avatar/avatar.js
@@ -3,7 +3,7 @@ import { Image, StyleSheet, Text, View, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 import { mix } from "yonius";
 
-import { IdentifiableMixin } from "../../../util";
+import { IdentifiableMixin, equal } from "../../../util";
 
 import { Touchable } from "../touchable";
 
@@ -50,13 +50,7 @@ export class Avatar extends mix(PureComponent).with(IdentifiableMixin) {
     }
 
     componentDidUpdate(prevProps) {
-        if (typeof prevProps.image === "number" && prevProps.image !== this.props.image) {
-            this.setState({ imageSrc: this.props.image });
-        } else if (
-            typeof prevProps.image === "object" &&
-            typeof this.props.image === "object" &&
-            prevProps.image.uri !== this.props.image.uri
-        ) {
+        if(!equal(prevProps.image, this.props.image)) {
             this.setState({ imageSrc: this.props.image });
         }
     }

--- a/react/components/atoms/avatar/avatar.js
+++ b/react/components/atoms/avatar/avatar.js
@@ -50,7 +50,7 @@ export class Avatar extends mix(PureComponent).with(IdentifiableMixin) {
     }
 
     componentDidUpdate(prevProps) {
-        if(!equal(prevProps.image, this.props.image)) {
+        if (!equal(prevProps.image, this.props.image)) {
             this.setState({ imageSrc: this.props.image });
         }
     }

--- a/react/components/atoms/avatar/avatar.js
+++ b/react/components/atoms/avatar/avatar.js
@@ -49,6 +49,18 @@ export class Avatar extends mix(PureComponent).with(IdentifiableMixin) {
         };
     }
 
+    componentDidUpdate(prevProps) {
+        if (typeof prevProps.image === "number" && prevProps.image !== this.props.image) {
+            this.setState({ imageSrc: this.props.image });
+        } else if (
+            typeof prevProps.image === "object" &&
+            typeof this.props.image === "object" &&
+            prevProps.image.uri !== this.props.image.uri
+        ) {
+            this.setState({ imageSrc: this.props.image });
+        }
+    }
+
     onLoadingError = () => {
         this.setState({ imageSrc: require("./assets/avatar.png") });
         if (this.props.onError) this.props.onError();


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Originated from https://github.com/ripe-tech/ripe-id-mobile/issues/2 |
| Dependencies | -- |
| Decisions | Allow update to the avatar image after first setup. Necessary when editing a profile picture, it should show the picture after the user chooses a new one. |
| Animated GIF | -- |
