### PR TITLE
Feat: Knob and overlay opacity configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* `ContainerOpenable` knob does not show if it is not meant to be pressable
+* `ContainerOpenable` overlay opacity controlled by props
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* `ContainerOpenable` knob does not show if it is not meant to be pressable
+* `ContainerOpenable` knob visibility controlled by props
 * `ContainerOpenable` overlay opacity controlled by props
 
 ### Fixed

--- a/react/components/atoms/container-openable/container-openable.js
+++ b/react/components/atoms/container-openable/container-openable.js
@@ -221,7 +221,6 @@ export class ContainerOpenable extends PureComponent {
                             onLayout={event => this._onHeaderLayout(event)}
                             {...this.props.headerProps}
                         >
-                            <View style={styles.knob} />
                             {this.props.header}
                         </View>
                     )}

--- a/react/components/atoms/container-openable/container-openable.js
+++ b/react/components/atoms/container-openable/container-openable.js
@@ -26,6 +26,7 @@ export class ContainerOpenable extends PureComponent {
             header: PropTypes.element,
             headerPressable: PropTypes.bool,
             headerProps: PropTypes.object,
+            showKnob: PropTypes.bool,
             onContentHeight: PropTypes.func,
             onVisible: PropTypes.func,
             style: ViewPropTypes.style
@@ -40,6 +41,7 @@ export class ContainerOpenable extends PureComponent {
             header: undefined,
             headerPressable: true,
             headerProps: {},
+            showKnob: true,
             onContentHeight: height => {},
             onVisible: visible => {},
             style: {}
@@ -215,7 +217,7 @@ export class ContainerOpenable extends PureComponent {
                             onPress={this.onHeaderPress}
                             {...this.props.headerProps}
                         >
-                            <View style={styles.knob} />
+                            {this.props.showKnob ? <View style={styles.knob} /> : null}
                             {this.props.header}
                         </TouchableOpacity>
                     ) : (
@@ -223,6 +225,7 @@ export class ContainerOpenable extends PureComponent {
                             onLayout={event => this._onHeaderLayout(event)}
                             {...this.props.headerProps}
                         >
+                            {this.props.showKnob ? <View style={styles.knob} /> : null}
                             {this.props.header}
                         </View>
                     )}

--- a/react/components/atoms/container-openable/container-openable.js
+++ b/react/components/atoms/container-openable/container-openable.js
@@ -21,6 +21,7 @@ export class ContainerOpenable extends PureComponent {
     static get propTypes() {
         return {
             animationsDuration: PropTypes.number,
+            targetOverlayOpacity: PropTypes.number,
             modal: PropTypes.bool,
             header: PropTypes.element,
             headerPressable: PropTypes.bool,
@@ -34,6 +35,7 @@ export class ContainerOpenable extends PureComponent {
     static get defaultProps() {
         return {
             animationsDuration: 300,
+            targetOverlayOpacity: 0.5,
             modal: true,
             header: undefined,
             headerPressable: true,
@@ -95,7 +97,7 @@ export class ContainerOpenable extends PureComponent {
                     easing: Easing.inOut(Easing.ease)
                 }),
                 Animated.timing(this.state.overlayOpacity, {
-                    toValue: 0.5,
+                    toValue: this.props.targetOverlayOpacity,
                     duration: this.props.animationsDuration,
                     useNativeDriver: true,
                     easing: Easing.inOut(Easing.ease)


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Originated by https://github.com/ripe-tech/ripe-id-mobile/issues/3 |
| Dependencies | -- |
| Decisions | Added props to control knob visibility and target opacity for the overlay animation. |