### PR TITLE
Select: Add border radius variant

### DIFF
--- a/react/components/molecules/select/select.js
+++ b/react/components/molecules/select/select.js
@@ -68,6 +68,10 @@ export class Select extends mix(PureComponent).with(IdentifiableMixin) {
         );
     };
 
+    _inputBorderRadius = () => {
+        if (this.props.variant === "round") return 6;
+    };
+
     _icon = () => {
         return <Icon icon={"chevron-down"} color={"#1b2632"} strokeWidth={2} />;
     };
@@ -102,6 +106,7 @@ export class Select extends mix(PureComponent).with(IdentifiableMixin) {
                 backgroundColor: "#f6f7f9",
                 borderColor: "#e4e8f0",
                 borderWidth: 1,
+                borderRadius: this._inputBorderRadius(),
                 fontFamily: baseStyles.FONT_BOOK,
                 fontSize: 14,
                 paddingLeft: 10,
@@ -112,6 +117,7 @@ export class Select extends mix(PureComponent).with(IdentifiableMixin) {
                 backgroundColor: "#f6f7f9",
                 borderColor: "#e4e8f0",
                 borderWidth: 1,
+                borderRadius: this._inputBorderRadius(),
                 fontFamily: baseStyles.FONT_BOOK,
                 fontSize: 14,
                 paddingLeft: 10,

--- a/react/components/molecules/select/select.stories.js
+++ b/react/components/molecules/select/select.stories.js
@@ -39,6 +39,14 @@ storiesOf("Molecules", module)
             },
             undefined
         );
+        const variant = select(
+            "Variant",
+            {
+                Round: "round",
+                Square: "square"
+            },
+            "square"
+        );
         const disabled = boolean("Disabled", false);
         const width = number("Width", -1);
 
@@ -48,6 +56,7 @@ storiesOf("Molecules", module)
                 options={options}
                 value={value}
                 disabled={disabled}
+                variant={variant}
                 width={width === -1 ? undefined : width}
             />
         );


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-id-mobile/issues/5 |
| Decisions | - Add select variant prop to allow the selection of square/round edges. |
| Animated GIF | Below |

### Variant square
![image](https://user-images.githubusercontent.com/24736423/125072285-4fa5d280-e0b2-11eb-9e99-d79f121f7e7a.png)

### Variant round
![image](https://user-images.githubusercontent.com/24736423/125072262-474d9780-e0b2-11eb-9895-4136a97ba091.png)

