### PR TITLE
Key values: prop to allow copy to clipboard on long press

### DIFF
--- a/react/components/molecules/key-value/key-value.js
+++ b/react/components/molecules/key-value/key-value.js
@@ -23,7 +23,7 @@ export class KeyValue extends mix(PureComponent).with(IdentifiableMixin) {
             iconWidth: PropTypes.number,
             iconStrokeWidth: PropTypes.number,
             pressable: PropTypes.bool,
-            longPressToClipboard: PropTypes.bool,
+            longPressCopiesToClipboard: PropTypes.bool,
             onPress: PropTypes.func,
             onButtonIconPress: PropTypes.func,
             onLongPress: PropTypes.func,
@@ -44,7 +44,7 @@ export class KeyValue extends mix(PureComponent).with(IdentifiableMixin) {
             iconWidth: undefined,
             iconStrokeWidth: undefined,
             pressable: false,
-            longPressToClipboard: false,
+            longPressCopiesToClipboard: false,
             onPress: () => {},
             onButtonIconPress: () => {},
             onLongPress: () => {},
@@ -76,7 +76,7 @@ export class KeyValue extends mix(PureComponent).with(IdentifiableMixin) {
     };
 
     _onLongPress = () => {
-        if (this.props.longPressToClipboard) toClipboard(this.props.value);
+        if (this.props.longPressCopiesToClipboard) toClipboard(this.props.value);
         this.props.onLongPress(this.props._key, this.props.value);
     };
 

--- a/react/components/molecules/key-value/key-value.js
+++ b/react/components/molecules/key-value/key-value.js
@@ -23,7 +23,7 @@ export class KeyValue extends mix(PureComponent).with(IdentifiableMixin) {
             iconWidth: PropTypes.number,
             iconStrokeWidth: PropTypes.number,
             pressable: PropTypes.bool,
-            longPressCopiesToClipboard: PropTypes.bool,
+            clipboard: PropTypes.bool,
             onPress: PropTypes.func,
             onButtonIconPress: PropTypes.func,
             onLongPress: PropTypes.func,
@@ -44,7 +44,7 @@ export class KeyValue extends mix(PureComponent).with(IdentifiableMixin) {
             iconWidth: undefined,
             iconStrokeWidth: undefined,
             pressable: false,
-            longPressCopiesToClipboard: false,
+            clipboard: false,
             onPress: () => {},
             onButtonIconPress: () => {},
             onLongPress: () => {},
@@ -76,7 +76,7 @@ export class KeyValue extends mix(PureComponent).with(IdentifiableMixin) {
     };
 
     _onLongPress = () => {
-        if (this.props.longPressCopiesToClipboard) toClipboard(this.props.value);
+        if (this.props.clipboard) toClipboard(this.props.value);
         this.props.onLongPress(this.props._key, this.props.value);
     };
 

--- a/react/components/molecules/key-value/key-value.js
+++ b/react/components/molecules/key-value/key-value.js
@@ -3,7 +3,7 @@ import { Platform, StyleSheet, Text, View, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 import { mix } from "yonius";
 
-import { IdentifiableMixin, baseStyles } from "../../../util";
+import { IdentifiableMixin, baseStyles, toClipboard } from "../../../util";
 
 import { ButtonIcon, Touchable } from "../../atoms";
 
@@ -23,6 +23,7 @@ export class KeyValue extends mix(PureComponent).with(IdentifiableMixin) {
             iconWidth: PropTypes.number,
             iconStrokeWidth: PropTypes.number,
             pressable: PropTypes.bool,
+            longPressToClipboard: PropTypes.bool,
             onPress: PropTypes.func,
             onButtonIconPress: PropTypes.func,
             onLongPress: PropTypes.func,
@@ -43,6 +44,7 @@ export class KeyValue extends mix(PureComponent).with(IdentifiableMixin) {
             iconWidth: undefined,
             iconStrokeWidth: undefined,
             pressable: false,
+            longPressToClipboard: false,
             onPress: () => {},
             onButtonIconPress: () => {},
             onLongPress: () => {},
@@ -69,6 +71,15 @@ export class KeyValue extends mix(PureComponent).with(IdentifiableMixin) {
         }
     };
 
+    _onPress = () => {
+        this.props.onPress(this.props._key, this.props.value);
+    };
+
+    _onLongPress = () => {
+        if (this.props.longPressToClipboard) toClipboard(this.props.value);
+        this.props.onLongPress(this.props._key, this.props.value);
+    };
+
     _style = () => {
         return [styles.keyValue, this._borderStyle(), this.props.style];
     };
@@ -78,8 +89,8 @@ export class KeyValue extends mix(PureComponent).with(IdentifiableMixin) {
             <Touchable
                 style={this._style()}
                 disabled={!this.props.pressable}
-                onPress={() => this.props.onPress(this.props._key, this.props.value)}
-                onLongPress={() => this.props.onLongPress(this.props._key, this.props.value)}
+                onPress={this._onPress}
+                onLongPress={this._onLongPress}
             >
                 <View style={styles.textContainer} {...this.id("key-value")}>
                     <Text style={this._keyStyle()} {...this.id("key-value-key")}>

--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -25,7 +25,7 @@ export class KeyValues extends PureComponent {
                     iconWidth: PropTypes.number,
                     iconStrokeWidth: PropTypes.number,
                     pressable: PropTypes.bool,
-                    longPressCopiesToClipboard: PropTypes.bool,
+                    clipboard: PropTypes.bool,
                     onPress: PropTypes.func,
                     onButtonIconPress: PropTypes.func,
                     onLongPress: PropTypes.func
@@ -132,7 +132,7 @@ export class KeyValues extends PureComponent {
                                 iconWidth={item.iconWidth}
                                 iconStrokeWidth={item.iconStrokeWidth}
                                 pressable={item.pressable}
-                                longPressCopiesToClipboard={item.longPressCopiesToClipboard}
+                                clipboard={item.clipboard}
                                 onPress={item.onPress}
                                 onButtonIconPress={item.onButtonIconPress}
                                 onLongPress={item.onLongPress}

--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -25,7 +25,7 @@ export class KeyValues extends PureComponent {
                     iconWidth: PropTypes.number,
                     iconStrokeWidth: PropTypes.number,
                     pressable: PropTypes.bool,
-                    longPressToClipboard: PropTypes.bool,
+                    longPressCopiesToClipboard: PropTypes.bool,
                     onPress: PropTypes.func,
                     onButtonIconPress: PropTypes.func,
                     onLongPress: PropTypes.func
@@ -132,7 +132,7 @@ export class KeyValues extends PureComponent {
                                 iconWidth={item.iconWidth}
                                 iconStrokeWidth={item.iconStrokeWidth}
                                 pressable={item.pressable}
-                                longPressToClipboard={item.longPressToClipboard}
+                                longPressCopiesToClipboard={item.longPressCopiesToClipboard}
                                 onPress={item.onPress}
                                 onButtonIconPress={item.onButtonIconPress}
                                 onLongPress={item.onLongPress}

--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -25,6 +25,7 @@ export class KeyValues extends PureComponent {
                     iconWidth: PropTypes.number,
                     iconStrokeWidth: PropTypes.number,
                     pressable: PropTypes.bool,
+                    longPressToClipboard: PropTypes.bool,
                     onPress: PropTypes.func,
                     onButtonIconPress: PropTypes.func,
                     onLongPress: PropTypes.func
@@ -131,6 +132,7 @@ export class KeyValues extends PureComponent {
                                 iconWidth={item.iconWidth}
                                 iconStrokeWidth={item.iconStrokeWidth}
                                 pressable={item.pressable}
+                                longPressToClipboard={item.longPressToClipboard}
                                 onPress={item.onPress}
                                 onButtonIconPress={item.onButtonIconPress}
                                 onLongPress={item.onLongPress}


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/pull/274#issuecomment-876237799 |
| Decisions | - Add `longPressToClipboard` to allow copy to clipboard after long press event. |
