### PR TITLE
fix: make text and opacity container smaller

### DIFF
--- a/react/components/atoms/avatar/avatar.js
+++ b/react/components/atoms/avatar/avatar.js
@@ -73,15 +73,15 @@ export class Avatar extends mix(PureComponent).with(IdentifiableMixin) {
     };
 
     _labelStyle = () => {
-        return [styles.label, { height: this.props.size / 3 }];
+        return [styles.label, { height: this.props.size / 4 }];
     };
 
     _labelTextStyle = () => {
         return [
             styles.labelText,
             {
-                lineHeight: this.props.size / 6,
-                fontSize: this.props.size / 6,
+                lineHeight: this.props.size / 8,
+                fontSize: this.props.size / 10,
                 maxWidth: this.props.size
             }
         ];


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | |
| Decisions | Make font size and opacity container height smaller. |
| Animated GIF | ![image](https://user-images.githubusercontent.com/25725586/125098437-e7b1b500-e0ce-11eb-9bbc-b7245ee90145.png) |
