### PR TITLE
Icon: Add icon sources through URI or local require

### DIFF
--- a/react/components/atoms/icon/icon.js
+++ b/react/components/atoms/icon/icon.js
@@ -40,8 +40,7 @@ export class Icon extends mix(PureComponent).with(IdentifiableMixin) {
 
     _icon() {
         if (icons[this.props.icon]) return icons[this.props.icon];
-        else if (typeof this.props.icon === "number") Image.resolveAssetSource(this.props.icon);
-        else throw new Error(`Unknown icon ${this.props.icon}`);
+        throw new Error(`Unknown icon ${this.props.icon}`);
     }
 
     _isUriIcon() {

--- a/react/components/atoms/icon/icon.js
+++ b/react/components/atoms/icon/icon.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from "react";
-import { ViewPropTypes } from "react-native";
-import { SvgXml } from "react-native-svg";
+import { Image, ViewPropTypes } from "react-native";
+import { SvgUri, SvgXml } from "react-native-svg";
 import PropTypes from "prop-types";
 import { mix } from "yonius";
 
@@ -10,7 +10,7 @@ import icons from "../../../assets/icons/";
 export class Icon extends mix(PureComponent).with(IdentifiableMixin) {
     static get propTypes() {
         return {
-            icon: PropTypes.string.isRequired,
+            icon: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
             fill: PropTypes.oneOfType([
                 PropTypes.string,
                 PropTypes.number,
@@ -40,10 +40,34 @@ export class Icon extends mix(PureComponent).with(IdentifiableMixin) {
 
     _icon() {
         if (icons[this.props.icon]) return icons[this.props.icon];
-        throw new Error(`Unknown icon ${this.props.icon}`);
+        else if (typeof this.props.icon === "number") Image.resolveAssetSource(this.props.icon);
+        else throw new Error(`Unknown icon ${this.props.icon}`);
     }
 
-    render() {
+    _isUriIcon() {
+        return typeof this.props.icon === "number" || this.props.icon.startsWith("http");
+    }
+
+    _renderSvgUri() {
+        const uri =
+            typeof this.props.icon === "number"
+                ? Image.resolveAssetSource(this.props.icon).uri
+                : this.props.icon;
+        return (
+            <SvgUri
+                uri={uri}
+                height={this.props.height}
+                width={this.props.width}
+                fill={this.props.fill}
+                stroke={this.props.color}
+                strokeWidth={this.props.strokeWidth}
+                style={this.props.style}
+                {...this.id(`icon-${this.props.uri}`)}
+            />
+        );
+    }
+
+    _renderSvgXml() {
         return (
             <SvgXml
                 xml={this._icon()}
@@ -56,6 +80,10 @@ export class Icon extends mix(PureComponent).with(IdentifiableMixin) {
                 {...this.id(`icon-${this.props.icon}`)}
             />
         );
+    }
+
+    render() {
+        return this._isUriIcon() ? this._renderSvgUri() : this._renderSvgXml();
     }
 }
 

--- a/react/components/atoms/icon/icon.js
+++ b/react/components/atoms/icon/icon.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from "react";
 import { Image, ViewPropTypes } from "react-native";
-import { SvgUri, SvgXml } from "react-native-svg";
+import { SvgCssUri, SvgXml } from "react-native-svg";
 import PropTypes from "prop-types";
 import { mix } from "yonius";
 
@@ -54,7 +54,7 @@ export class Icon extends mix(PureComponent).with(IdentifiableMixin) {
                 ? Image.resolveAssetSource(this.props.icon).uri
                 : this.props.icon;
         return (
-            <SvgUri
+            <SvgCssUri
                 uri={uri}
                 height={this.props.height}
                 width={this.props.width}


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-id-mobile/issues/5 |
| Decisions | - Add feature to allow icon component to render an SVG icon from a certain uri such as icon="http://thenewcode.com/assets/svg/accessibility.svg" but also allow project specific requires such as icon="require('./assets/icon.svg')" by using already imported module https://github.com/react-native-svg/react-native-svg#use-with-content-loaded-from-uri  |
