### PR TITLE
Feat: Enable container openable overlay press by prop

### DIFF
--- a/react/components/atoms/container-openable/container-openable.js
+++ b/react/components/atoms/container-openable/container-openable.js
@@ -27,7 +27,7 @@ export class ContainerOpenable extends PureComponent {
             headerPressable: PropTypes.bool,
             headerProps: PropTypes.object,
             showKnob: PropTypes.bool,
-            enableOverlayPress: PropTypes.bool,
+            overlayPress: PropTypes.bool,
             onContentHeight: PropTypes.func,
             onVisible: PropTypes.func,
             style: ViewPropTypes.style
@@ -43,7 +43,7 @@ export class ContainerOpenable extends PureComponent {
             headerPressable: true,
             headerProps: {},
             showKnob: true,
-            enableOverlayPress: true,
+            overlayPress: true,
             onContentHeight: height => {},
             onVisible: visible => {},
             style: {}
@@ -144,7 +144,7 @@ export class ContainerOpenable extends PureComponent {
     }
 
     onOverlayPress = () => {
-        if (this.props.enableOverlayPress) this.close();
+        if (this.props.overlayPress) this.close();
     };
 
     onModalRequestClose = () => {

--- a/react/components/atoms/container-openable/container-openable.js
+++ b/react/components/atoms/container-openable/container-openable.js
@@ -27,6 +27,7 @@ export class ContainerOpenable extends PureComponent {
             headerPressable: PropTypes.bool,
             headerProps: PropTypes.object,
             showKnob: PropTypes.bool,
+            enableOverlayPress: PropTypes.bool,
             onContentHeight: PropTypes.func,
             onVisible: PropTypes.func,
             style: ViewPropTypes.style
@@ -42,6 +43,7 @@ export class ContainerOpenable extends PureComponent {
             headerPressable: true,
             headerProps: {},
             showKnob: true,
+            enableOverlayPress: true,
             onContentHeight: height => {},
             onVisible: visible => {},
             style: {}
@@ -142,7 +144,7 @@ export class ContainerOpenable extends PureComponent {
     }
 
     onOverlayPress = () => {
-        this.close();
+        if (this.props.enableOverlayPress) this.close();
     };
 
     onModalRequestClose = () => {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Originated by https://github.com/ripe-tech/ripe-id-mobile/issues/3 |
| Dependencies | -- |
| Decisions | New prop that controls whether the overlay is pressable to close the container |
