### PR TITLE
Icon: Add svg icon option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Support for `View more` button in key-values
 * Date Input support for margin and border overriding as props
 * Form component
+* Support for URI and SVG direct import option for `Icon`
 
 ### Changed
 

--- a/react/components/atoms/icon/icon.js
+++ b/react/components/atoms/icon/icon.js
@@ -39,12 +39,17 @@ export class Icon extends mix(PureComponent).with(IdentifiableMixin) {
     }
 
     _icon() {
+        if (this._isSvgIcon()) return this.props.icon;
         if (icons[this.props.icon]) return icons[this.props.icon];
         throw new Error(`Unknown icon ${this.props.icon}`);
     }
 
     _isUriIcon() {
         return typeof this.props.icon === "number" || this.props.icon.startsWith("http");
+    }
+
+    _isSvgIcon() {
+        return typeof this.props.icon === "string" && this.props.icon.startsWith("<svg");
     }
 
     _renderSvgUri() {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-id-mobile/issues/5 |
| Decisions | - Add option to receive imported icon directly from an external project. As in react native we can't do dynamic imports like `require(./${iconName}.svg)` it's beneficial to add more options to import icons in the icon component. Currently we have by icon name, URI link and application import. This will add the option to directly receive an icon from an external project. |
