### PR TITLE
Fix: Link.url is not required

### DIFF
--- a/react/components/atoms/link/link.js
+++ b/react/components/atoms/link/link.js
@@ -8,7 +8,7 @@ export class Link extends PureComponent {
     static get propTypes() {
         return {
             text: PropTypes.string,
-            url: PropTypes.string.isRequired,
+            url: PropTypes.string,
             onPress: PropTypes.func,
             color: PropTypes.string,
             styleText: Text.propTypes.style,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | `Link.url` prop is not required. It defaults to the [`onPress` callback](https://github.com/ripe-tech/ripe-components-react-native/blob/master/react/components/atoms/link/link.js#L42) |

