### PR TITLE
fix: input animated keyboard avoiding view problem fix

### DIFF
--- a/react/components/molecules/input-animated/input-animated.js
+++ b/react/components/molecules/input-animated/input-animated.js
@@ -61,8 +61,8 @@ export class InputAnimated extends mix(PureComponent).with(IdentifiableMixin) {
         this.inputBorderOpacityBlur = 0;
         this.inputBorderOpacityFocus = 1;
 
-        this.inputYTransformBlur = 0;
-        this.inputYTransformFocus = -35;
+        this.inputYMarginTopBlur = 0;
+        this.inputYMarginTopFocus = -35;
 
         this.state = {
             valueData: this.props.value,
@@ -73,7 +73,7 @@ export class InputAnimated extends mix(PureComponent).with(IdentifiableMixin) {
             underlineOpacity: new Animated.Value(this.underlineOpacityBlur),
             underlineYTransform: new Animated.Value(this.underlineYTransformBlur),
             inputBorderOpacity: new Animated.Value(this.inputBorderOpacityBlur),
-            inputYTransform: new Animated.Value(this.inputYTransformBlur)
+            inputYMarginTop: new Animated.Value(this.inputYMarginTopBlur)
         };
     }
 
@@ -128,7 +128,7 @@ export class InputAnimated extends mix(PureComponent).with(IdentifiableMixin) {
                 borderBottomColor: this.state.focused
                     ? this.props.borderBottomActiveColor
                     : "#c3c9cf",
-                transform: [{ translateY: this.state.inputYTransform }],
+                marginTop: this.state.inputYMarginTop,
                 opacity: this.state.inputBorderOpacity
             }
         ];
@@ -187,8 +187,8 @@ export class InputAnimated extends mix(PureComponent).with(IdentifiableMixin) {
                 duration: this.animationDuration,
                 useNativeDriver: false
             }),
-            Animated.timing(this.state.inputYTransform, {
-                toValue: blur ? this.inputYTransformBlur : this.inputYTransformFocus,
+            Animated.timing(this.state.inputYMarginTop, {
+                toValue: blur ? this.inputYMarginTopBlur : this.inputYMarginTopFocus,
                 duration: this.animationDuration,
                 useNativeDriver: false
             })
@@ -235,6 +235,7 @@ export class InputAnimated extends mix(PureComponent).with(IdentifiableMixin) {
                 <Animated.View style={this._underlineStyle()} />
                 <Animated.View style={this._inputStyle()}>
                     <Input
+                        style={styles.inputComponent}
                         ref={el => (this.input = el)}
                         value={this.state.valueData}
                         placeholder={this.props.placeholder || this.props.label}
@@ -270,6 +271,9 @@ const styles = StyleSheet.create({
     },
     input: {
         borderBottomWidth: 1
+    },
+    inputComponent: {
+        paddingVertical: 10
     }
 });
 

--- a/react/components/molecules/input-animated/input-animated.js
+++ b/react/components/molecules/input-animated/input-animated.js
@@ -254,10 +254,10 @@ export class InputAnimated extends mix(PureComponent).with(IdentifiableMixin) {
 
 const styles = StyleSheet.create({
     inputAnimated: {
-        fontFamily: baseStyles.FONT_BOLD,
         maxHeight: 50
     },
     header: {
+        fontFamily: baseStyles.FONT_BOLD,
         height: 50,
         alignContent: "flex-end"
     },
@@ -270,6 +270,7 @@ const styles = StyleSheet.create({
         position: "absolute"
     },
     input: {
+        fontFamily: baseStyles.FONT_BOLD,
         borderBottomWidth: 1
     },
     inputComponent: {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | When using input animated with KeyboardAvoidingView, the keyboard would appear above the input. |
| Dependencies | |
| Decisions | • Input animated translateY animation was causing problems with KeyboardAvoidingView logic of translating the view to not appear above input. By changing to marginTop, the problem was fixed. <br> • Adding paddingTop to the input allowed the keyboard to give spacing to the whole input and not cutting it in half. |
| Animated GIF | -- |
