### PR TITLE
fix: keyboard avoiding view fix for ios with multiline input

### DIFF
--- a/react/components/atoms/textarea/textarea.js
+++ b/react/components/atoms/textarea/textarea.js
@@ -81,6 +81,7 @@ export class TextArea extends mix(PureComponent).with(IdentifiableMixin) {
                 ref={el => (this.textInputComponent = el)}
                 style={this._style()}
                 placeholder={this.props.placeholder}
+                scrollEnabled={false}
                 multiline={this.props.multiline}
                 onSubmitEditing={this.onSubmit}
                 onChangeText={this.props.onValue}

--- a/react/components/organisms/form/form.js
+++ b/react/components/organisms/form/form.js
@@ -108,10 +108,6 @@ export class Form extends PureComponent {
         await this.discard();
     };
 
-    _style = () => {
-        return [styles.form, this.props.style];
-    };
-
     _renderInputComponent = ({ value, type, label, ...args }) => {
         switch (type) {
             case "text":
@@ -170,7 +166,7 @@ export class Form extends PureComponent {
 
     render() {
         return (
-            <ScrollView style={this._style()}>
+            <ScrollView style={this.props.style}>
                 {this._renderSections()}
                 {(this.props.onSave || this.props.onDiscard) && (
                     <View style={styles.buttons}>
@@ -200,7 +196,6 @@ export class Form extends PureComponent {
 }
 
 const styles = StyleSheet.create({
-    form: {},
     section: {
         flex: 1
     },

--- a/react/components/organisms/form/form.js
+++ b/react/components/organisms/form/form.js
@@ -200,9 +200,7 @@ export class Form extends PureComponent {
 }
 
 const styles = StyleSheet.create({
-    form: {
-        flex: 1
-    },
+    form: {},
     section: {
         flex: 1
     },


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Known problem with multiline TexInput and keyboardAvoidingView. |
| Dependencies | |
| Decisions | Fixes it with https://github.com/facebook/react-native/issues/16826#issuecomment-512111075 |
| Animated GIF | |
