### PR TITLE
Button: fix util undefined import

### DIFF
--- a/react/components/atoms/button/button.js
+++ b/react/components/atoms/button/button.js
@@ -3,8 +3,9 @@ import { ActivityIndicator, Platform, StyleSheet, Text, View, ViewPropTypes } fr
 import LinearGradient from "react-native-linear-gradient";
 import PropTypes from "prop-types";
 import { mix } from "yonius";
+import { capitalize } from "ripe-commons-native";
 
-import { IdentifiableMixin, baseStyles, capitalize } from "../../../util";
+import { IdentifiableMixin, baseStyles } from "../../../util";
 
 import { Icon } from "../icon";
 import { Touchable } from "../touchable";

--- a/react/components/molecules/button-toggle/button-toggle.js
+++ b/react/components/molecules/button-toggle/button-toggle.js
@@ -1,9 +1,10 @@
 import React, { PureComponent } from "react";
 import { StyleSheet, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
+import { capitalize } from "ripe-commons-native";
 import { mix } from "yonius";
 
-import { IdentifiableMixin, capitalize } from "../../../util";
+import { IdentifiableMixin } from "../../../util";
 
 import { Button } from "../../atoms";
 

--- a/react/components/molecules/card/card.js
+++ b/react/components/molecules/card/card.js
@@ -1,12 +1,13 @@
 import React, { PureComponent } from "react";
 import { StyleSheet, Text, View, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
+import { capitalize } from "ripe-commons-native";
 
 import { Avatar } from "../../atoms/avatar";
 import { Icon } from "../../atoms";
 import { Item } from "../item";
 
-import { baseStyles, capitalize } from "../../../util";
+import { baseStyles } from "../../../util";
 
 export class Card extends PureComponent {
     static get propTypes() {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | `capitalize` is no longer defined as a local util but in button component it is still being imported as such. |
| Decisions | - Move capitalize import to ripe-commons-native |
