### PR TITLE
Select: Adapt padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* Adapt select left padding to be consistent among other components
 
 ### Fixed
 

--- a/react/components/molecules/select/select.js
+++ b/react/components/molecules/select/select.js
@@ -123,7 +123,7 @@ export class Select extends mix(PureComponent).with(IdentifiableMixin) {
                 borderRadius: this._inputBorderRadius(),
                 fontFamily: baseStyles.FONT_BOOK,
                 fontSize: 14,
-                paddingLeft: 10,
+                paddingLeft: 15,
                 height: 40
             },
             inputIOSContainer: {
@@ -134,7 +134,7 @@ export class Select extends mix(PureComponent).with(IdentifiableMixin) {
                 borderRadius: this._inputBorderRadius(),
                 fontFamily: baseStyles.FONT_BOOK,
                 fontSize: 14,
-                paddingLeft: 10,
+                paddingLeft: 15,
                 height: 40,
                 justifyContent: "center"
             },


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | - Select left padding is not consistent with other components. |
| Decisions | - Adapt select's left padding to 15 pixels so it matches other components spacing scheme. |
| Animated GIF | Below |

### Before
![image](https://user-images.githubusercontent.com/24736423/126350816-8b8a11b5-87b5-4f32-8d39-a8625724a0a3.png)

### After
![image](https://user-images.githubusercontent.com/24736423/126350732-b72da5d9-e1ac-48b1-832e-10816c7dd050.png)
