### PR TITLE
feat: override button toggle style

### DIFF
--- a/react/components/molecules/button-toggle/button-toggle.js
+++ b/react/components/molecules/button-toggle/button-toggle.js
@@ -147,7 +147,9 @@ const styles = StyleSheet.create({
     buttonToggle: {
         overflow: "hidden",
         minWidth: 60,
-        borderRadius: 0
+        borderRadius: 0,
+        flex: 1,
+        width: "100%"
     },
     buttonToggleLeft: {
         borderRadius: 0,

--- a/react/components/molecules/button-toggle/button-toggle.js
+++ b/react/components/molecules/button-toggle/button-toggle.js
@@ -117,7 +117,8 @@ export class ButtonToggle extends mix(PureComponent).with(IdentifiableMixin) {
             this.props.direction === "left" ? styles[this._styleName("buttonToggleLeft")] : {},
             this.props.direction === "right" ? styles[this._styleName("buttonToggleRight")] : {},
             this.props.direction === "top" ? styles[this._styleName("buttonToggleTop")] : {},
-            this.props.direction === "bottom" ? styles[this._styleName("buttonToggleBottom")] : {}
+            this.props.direction === "bottom" ? styles[this._styleName("buttonToggleBottom")] : {},
+            this.props.style
         ];
     };
 

--- a/react/components/organisms/button-group/button-group.js
+++ b/react/components/organisms/button-group/button-group.js
@@ -19,7 +19,8 @@ export class ButtonGroup extends mix(PureComponent).with(IdentifiableMixin) {
             toggle: PropTypes.bool,
             orientation: PropTypes.string,
             onUpdateValue: PropTypes.func,
-            style: ViewPropTypes.style
+            style: ViewPropTypes.style,
+            buttonStyle: ViewPropTypes.style
         };
     }
 
@@ -34,7 +35,8 @@ export class ButtonGroup extends mix(PureComponent).with(IdentifiableMixin) {
             toggle: true,
             orientation: "horizontal",
             onUpdateValue: value => {},
-            style: {}
+            style: {},
+            buttonStyle: {}
         };
     }
 
@@ -88,11 +90,15 @@ export class ButtonGroup extends mix(PureComponent).with(IdentifiableMixin) {
         ];
     };
 
+    buttonStyle = () => {
+        return [styles.buttonToggle, this.props.buttonStyle];
+    };
+
     _renderButtons = () => {
         return this.props.items.map((item, index) => (
             <ButtonToggle
                 key={item.value}
-                style={styles.buttonToggle}
+                style={this.buttonStyle()}
                 text={item.label || item.value}
                 value={this.state.valueData === item.value}
                 buttonProps={{


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | From https://github.com/ripe-tech/ripe-id-mobile/issues/1#issuecomment-883464734, necessary to override the border radius of the flat variant. |
| Dependencies | -- |
| Decisions | Allow override of button toggle style. |
| Animated GIF | -- |
