### PR TITLE
Feat: Add onSubmitEditing prop to Input and InputAnimated

### DIFF
--- a/react/components/atoms/input/input.js
+++ b/react/components/atoms/input/input.js
@@ -16,7 +16,8 @@ export class Input extends mix(PureComponent).with(IdentifiableMixin) {
             secureTextEntry: PropTypes.bool,
             onValueUpdate: PropTypes.func,
             onFocus: PropTypes.func,
-            onBlur: PropTypes.func
+            onBlur: PropTypes.func,
+            onSubmitEditing: PropTypes.func
         };
     }
 
@@ -111,6 +112,7 @@ export class Input extends mix(PureComponent).with(IdentifiableMixin) {
                 onChangeText={this.onChangeValue}
                 onBlur={this.props.onBlur}
                 onFocus={this.props.onFocus}
+                onSubmitEditing={this.props.onSubmitEditing}
                 {...this.id("input-ripe")}
             />
         );

--- a/react/components/molecules/input-animated/input-animated.js
+++ b/react/components/molecules/input-animated/input-animated.js
@@ -19,7 +19,8 @@ export class InputAnimated extends mix(PureComponent).with(IdentifiableMixin) {
             style: ViewPropTypes.style,
             onValueUpdate: PropTypes.func,
             onBlur: PropTypes.func,
-            onFocus: PropTypes.func
+            onFocus: PropTypes.func,
+            onSubmitEditing: PropTypes.func
         };
     }
 
@@ -34,7 +35,8 @@ export class InputAnimated extends mix(PureComponent).with(IdentifiableMixin) {
             style: {},
             onValueUpdate: value => {},
             onFocus: () => {},
-            onBlur: () => {}
+            onBlur: () => {},
+            onSubmitEditing: event => {}
         };
     }
 
@@ -245,6 +247,7 @@ export class InputAnimated extends mix(PureComponent).with(IdentifiableMixin) {
                         onValueUpdate={this.onChangeValue}
                         onFocus={this._onFocus}
                         onBlur={this._onBlur}
+                        onSubmitEditing={this.props.onSubmitEditing}
                     />
                 </Animated.View>
             </Touchable>


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Originated by https://github.com/ripe-tech/ripe-id-mobile/issues/3 |
| Dependencies | -- |
| Decisions | Added props to propagate the on submit action to react native's [TextInput#onSubmitEditing](https://reactnative.dev/docs/textinput#onsubmitediting) |

