### PR TITLE
Select: Add right padding to select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Better color for the tabs text, removed the bold font on selected
+* Add right padding in select to account for the arrow icon space.
 
 ### Fixed
 

--- a/react/components/molecules/select/select.js
+++ b/react/components/molecules/select/select.js
@@ -124,6 +124,7 @@ export class Select extends mix(PureComponent).with(IdentifiableMixin) {
                 fontFamily: baseStyles.FONT_BOOK,
                 fontSize: 14,
                 paddingLeft: 15,
+                paddingRight: 35,
                 height: 40
             },
             inputIOSContainer: {

--- a/react/components/molecules/select/select.js
+++ b/react/components/molecules/select/select.js
@@ -135,6 +135,7 @@ export class Select extends mix(PureComponent).with(IdentifiableMixin) {
                 fontFamily: baseStyles.FONT_BOOK,
                 fontSize: 14,
                 paddingLeft: 15,
+                paddingRight: 35,
                 height: 40,
                 justifyContent: "center"
             },

--- a/react/components/molecules/select/select.js
+++ b/react/components/molecules/select/select.js
@@ -124,7 +124,7 @@ export class Select extends mix(PureComponent).with(IdentifiableMixin) {
                 fontFamily: baseStyles.FONT_BOOK,
                 fontSize: 14,
                 paddingLeft: 15,
-                paddingRight: 35,
+                paddingRight: 38,
                 height: 40
             },
             inputIOSContainer: {
@@ -136,7 +136,7 @@ export class Select extends mix(PureComponent).with(IdentifiableMixin) {
                 fontFamily: baseStyles.FONT_BOOK,
                 fontSize: 14,
                 paddingLeft: 15,
-                paddingRight: 35,
+                paddingRight: 38,
                 height: 40,
                 justifyContent: "center"
             },


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | - Add missing right padding to select to account for the arrow icon space that is always present. |
| Animated GIF | Below |

### Before
<img width="47" alt="imagem" src="https://user-images.githubusercontent.com/24736423/127135600-3d2282c2-8b32-47ce-a6d4-b714ec61ef05.png">


### After
<img width="63" alt="imagem" src="https://user-images.githubusercontent.com/24736423/127136157-3372c097-a4a0-4a5a-80a3-1a968da200d9.png">
