### PR TITLE
Select: fix touchable area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Touchable area not being fully covered on select.
 
 ## [0.5.1] - 2021-07-26
 

--- a/react/components/molecules/select/select.js
+++ b/react/components/molecules/select/select.js
@@ -160,6 +160,7 @@ export class Select extends mix(PureComponent).with(IdentifiableMixin) {
                     placeholder={{ label: this.props.placeholder, value: null }}
                     disabled={this.props.disabled}
                     useNativeAndroidPickerStyle={false}
+                    fixAndroidTouchableBug={true}
                     Icon={this._icon}
                     onValueChange={this.onValueChange}
                 />

--- a/react/components/molecules/select/select.js
+++ b/react/components/molecules/select/select.js
@@ -17,6 +17,7 @@ export class Select extends mix(PureComponent).with(IdentifiableMixin) {
             colorVariant: PropTypes.string,
             placeholder: PropTypes.string,
             disabled: PropTypes.bool,
+            fixAndroidTouchableBug: PropTypes.bool,
             width: PropTypes.number,
             onUpdateValue: PropTypes.func,
             style: ViewPropTypes.style
@@ -31,6 +32,7 @@ export class Select extends mix(PureComponent).with(IdentifiableMixin) {
             shapeVariant: "round",
             colorVariant: "white",
             disabled: false,
+            fixAndroidTouchableBug: true,
             width: undefined,
             keyTimeout: 500,
             onUpdateValue: () => {},
@@ -160,7 +162,7 @@ export class Select extends mix(PureComponent).with(IdentifiableMixin) {
                     placeholder={{ label: this.props.placeholder, value: null }}
                     disabled={this.props.disabled}
                     useNativeAndroidPickerStyle={false}
-                    fixAndroidTouchableBug={true}
+                    fixAndroidTouchableBug={this.props.fixAndroidTouchableBug}
                     Icon={this._icon}
                     onValueChange={this.onValueChange}
                 />


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-id-mobile/issues/5#issuecomment-888248323 - select touchable area is not properly covering the arrow icon. |
| Decisions | - Add component fix prop [fixAndroidTouchableBug](https://github.com/lawnstarter/react-native-picker-select/issues/354) |