### PR TITLE
Listing: set of improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Add new profile component
+* Add `onEndReachedThreshold`, `refreshing`, `loading` and `onFilter` props to listing.
 
 ### Changed
 

--- a/react/components/organisms/listing/listing.js
+++ b/react/components/organisms/listing/listing.js
@@ -25,7 +25,10 @@ export class Listing extends Component {
             emptyItemsText: PropTypes.string,
             search: PropTypes.bool,
             loading: PropTypes.bool,
+            refreshing: PropTypes.bool,
             flatListProps: PropTypes.object,
+            onEndReachedThreshold: PropTypes.number,
+            onFilter: PropTypes.func,
             style: ViewPropTypes.style,
             scrollViewStyle: ViewPropTypes.style,
             scrollViewContainerStyle: ViewPropTypes.style
@@ -41,6 +44,7 @@ export class Listing extends Component {
             emptyItemsText: "No items",
             search: true,
             loading: false,
+            refreshing: false,
             flatListProps: {},
             onFilter: async () => {},
             style: {},
@@ -228,17 +232,17 @@ export class Listing extends Component {
                     key={"items"}
                     style={styles.flatList}
                     data={this.state.items}
-                    refreshing={this.state.refreshing}
+                    refreshing={this.props.refreshing && this.state.refreshing}
                     onRefresh={this.onRefresh}
                     onEndReached={this.onEndReached}
-                    onEndReachedThreshold={0.6}
+                    onEndReachedThreshold={this.props.onEndReachedThreshold}
                     renderItem={({ item, index }) => this.props.renderItem(item, index)}
                     keyExtractor={item => String(item.id)}
                     ListEmptyComponent={this._renderEmptyList()}
                     ListFooterComponent={<View style={styles.flatListBottom} />}
                     {...this.props.flatListProps}
                 />
-                {this.state.loading && (
+                {this.props.loading && this.state.loading && (
                     <ActivityIndicator
                         style={styles.loadingIndicator}
                         size="large"

--- a/react/components/organisms/listing/listing.js
+++ b/react/components/organisms/listing/listing.js
@@ -100,6 +100,7 @@ export class Listing extends Component {
     };
 
     onFilter = async value => {
+        await this.props.onFilter(value);
         this.setState({ filters: value }, async () => await this.refresh());
     };
 

--- a/react/components/organisms/listing/listing.js
+++ b/react/components/organisms/listing/listing.js
@@ -42,10 +42,7 @@ export class Listing extends Component {
             search: true,
             loading: false,
             flatListProps: {},
-            onSearch: async () => {},
             onFilter: async () => {},
-            onRefresh: async () => {},
-            onEndReached: async () => {},
             style: {},
             scrollViewStyle: {},
             scrollViewContainerStyle: {}


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | - Add refreshing and loading props to toggle the visibility of such loading indicators. <br> - Add `onEndReachedThreshold` prop with no default value (undefined default value) so the threshold works similar to what we had before https://github.com/ripe-tech/ripe-robin-revamp/pull/285#issuecomment-888996058. <br> - Add `onFilter` callback prop as it can be useful to maintain a state of the current filter in the father component. <br> - Small cleanup |
