### PR TITLE
Avatar: add prop imageProps

### DIFF
--- a/react/components/atoms/avatar/avatar.js
+++ b/react/components/atoms/avatar/avatar.js
@@ -22,6 +22,7 @@ export class Avatar extends mix(PureComponent).with(IdentifiableMixin) {
                 right: PropTypes.number.isRequired,
                 bottom: PropTypes.number.isRequired
             }),
+            imageProps: PropTypes.object,
             onPress: PropTypes.func,
             onError: PropTypes.func,
             style: ViewPropTypes.style
@@ -36,6 +37,7 @@ export class Avatar extends mix(PureComponent).with(IdentifiableMixin) {
             borderRadius: 100,
             resizeMode: "contain",
             hitSlop: { top: 20, left: 20, right: 20, bottom: 20 },
+            imageProps: {},
             onPress: undefined,
             onError: undefined,
             style: {}
@@ -114,6 +116,7 @@ export class Avatar extends mix(PureComponent).with(IdentifiableMixin) {
                     style={styles.image}
                     resizeMode={this.props.resizeMode}
                     onError={this.onLoadingError}
+                    {...this.props.imageProps}
                     {...this.id("avatar")}
                 />
                 {this._renderLabel()}


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | - Add `imageProps` prop so we can override React's [Image](https://reactnative.dev/docs/image) default behavior such as setting `fadeDuration: 0`. |

