### PR TITLE
feat: support for different button on button group

### DIFF
--- a/react/components/organisms/button-group/button-group.js
+++ b/react/components/organisms/button-group/button-group.js
@@ -74,7 +74,7 @@ export class ButtonGroup extends mix(PureComponent).with(IdentifiableMixin) {
     onUpdateActive = value => {
         if (!this.props.toggle) return;
 
-        this.toggleButton(item.value);
+        this.toggleButton(value);
     };
 
     onPress = item => {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | - Support for overriding the button inside button group <br>  - New props `variantActive` and `buttonActiveStyle`, allowing to set different style and variant when the button is selected (if the toggle behaviour is enabled). <br> - Fixes to button toggle style override <br> - Button group style override support. <br> No breaking changes. |
| Animated GIF | Override example, using custom `Button` and `variantActive`: <br> ![button-group-override](https://user-images.githubusercontent.com/25725586/128714384-8f692a15-f904-4c62-af47-ee153ac2bac7.gif)|
