### PR TITLE
feat: allow wrap on button group buttons

### DIFF
--- a/react/components/organisms/button-group/button-group.js
+++ b/react/components/organisms/button-group/button-group.js
@@ -176,7 +176,12 @@ export class ButtonGroup extends mix(PureComponent).with(IdentifiableMixin) {
 
 const styles = StyleSheet.create({
     buttonGroup: {
-        overflow: "hidden"
+        overflow: "hidden",
+        flexWrap: "wrap"
+    },
+    buttonToggle: {
+        flexShrink: 0,
+        flexGrow: 0
     }
 });
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | https://github.com/ripe-tech/ripe-components-react-native/pull/268 |
| Decisions | Support wrapping on button group buttons. |
| Animated GIF | <img width="621" alt="image" src="https://user-images.githubusercontent.com/25725586/128885495-27a1f27e-4711-4151-b793-6f40b93ed98c.png"><img width="321" alt="image" src="https://user-images.githubusercontent.com/25725586/128885576-6736bfde-1e53-41c0-bd80-010a2df9f463.png"> |
