### PR TITLE
Button: improve button disabled style and onLongPress

### DIFF
--- a/react/components/atoms/button/button.js
+++ b/react/components/atoms/button/button.js
@@ -75,6 +75,7 @@ export class Button extends mix(PureComponent).with(IdentifiableMixin) {
             gradientColors: ["#4a6fe9", "#6687f6"],
             width: undefined,
             onPress: () => {},
+            onLongPress: () => {},
             style: {},
             containerStyle: {},
             styles: styles
@@ -217,6 +218,7 @@ export class Button extends mix(PureComponent).with(IdentifiableMixin) {
                 activeOpacity={0.8}
                 disabled={this.props.disabled}
                 onPress={this.props.onPress}
+                onLongPress={this.props.onLongPress}
                 {...this.id(`button-${this.props.text}`)}
             >
                 {this._renderButton()}

--- a/react/components/atoms/button/button.js
+++ b/react/components/atoms/button/button.js
@@ -103,6 +103,7 @@ export class Button extends mix(PureComponent).with(IdentifiableMixin) {
             this.props.styles.button,
             { width: this.props.width },
             this.props.backgroundColor ? { backgroundColor: this.props.backgroundColor } : {},
+            this.props.disabled ? this.props.styles.buttonDisabled : {},
             this.props.style
         ];
     };
@@ -138,7 +139,6 @@ export class Button extends mix(PureComponent).with(IdentifiableMixin) {
             { width: this.props.width },
             { justifyContent: this._align() },
             this.props.backgroundColor ? { backgroundColor: this.props.backgroundColor } : {},
-            this.props.disabled ? this.props.styles.buttonDisabled : {},
             this.props.containerStyle
         ];
     };
@@ -231,8 +231,7 @@ const styles = StyleSheet.create({
         borderRadius: 6
     },
     buttonDisabled: {
-        opacity: 0.5,
-        fontSize: 120
+        opacity: 0.5
     },
     container: {
         height: 48,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | - Improve button disabled style by setting the opacity to the button (like in ripe-white) instead of to the text container. <br> - Add `onLongPress` handler |
| Animated GIF | Below |

#### Before
<img width="62" alt="image" src="https://user-images.githubusercontent.com/24736423/130636407-1a067540-caf4-4604-a060-e8e61e227533.png">

#### After
<img width="62" alt="image" src="https://user-images.githubusercontent.com/24736423/130636464-61e5bb51-e843-4787-abde-3fb0bd69b2de.png">
