### PR TITLE
feat: button loading indicator position

### DIFF
--- a/react/components/atoms/button/button.js
+++ b/react/components/atoms/button/button.js
@@ -172,29 +172,17 @@ export class Button extends mix(PureComponent).with(IdentifiableMixin) {
     };
 
     _renderLoading() {
-        switch (this.props.loadingPosition) {
-            case "left":
-                return (
-                    <>
-                        <ActivityIndicator style={this._loadingStyle()} color="#ffffff" />
-                        <Text style={[this._textStyle()]}>{this.props.text}</Text>
-                    </>
-                );
-            case "right":
-                return (
-                    <>
-                        <Text style={[this._textStyle()]}>{this.props.text}</Text>
-                        <ActivityIndicator style={this._loadingStyle()} color="#ffffff" />
-                    </>
-                );
-            case "center":
-            default:
-                return (
-                    <>
-                        <ActivityIndicator style={this._loadingStyle()} color="#ffffff" />
-                    </>
-                );
-        }
+        return (
+            <>
+                {this.props.loadingPosition === "right" && (
+                    <Text style={this._textStyle()}>{this.props.text}</Text>
+                )}
+                <ActivityIndicator style={this._loadingStyle()} color="#ffffff" />
+                {this.props.loadingPosition === "left" && (
+                    <Text style={this._textStyle()}>{this.props.text}</Text>
+                )}
+            </>
+        );
     }
 
     _renderLeft() {

--- a/react/components/atoms/button/button.js
+++ b/react/components/atoms/button/button.js
@@ -157,12 +157,7 @@ export class Button extends mix(PureComponent).with(IdentifiableMixin) {
     _loadingStyle = () => {
         return [
             this.props.styles.container,
-            {
-                position: "absolute",
-                justifyContent: "center",
-                paddingHorizontal: 0,
-                paddingVertical: 0
-            },
+            styles.activityIndicator,
             this.props.loadingPosition === "right"
                 ? { right: 15 }
                 : this.props.loadingPosition === "left"
@@ -286,6 +281,12 @@ const styles = StyleSheet.create({
     },
     textFlat: {
         color: "#4f7af8"
+    },
+    activityIndicator: {
+        position: "absolute",
+        justifyContent: "center",
+        paddingHorizontal: 0,
+        paddingVertical: 0
     }
 });
 

--- a/react/components/atoms/button/button.js
+++ b/react/components/atoms/button/button.js
@@ -20,6 +20,7 @@ export class Button extends mix(PureComponent).with(IdentifiableMixin) {
             leftSlot: PropTypes.any,
             rightSlot: PropTypes.any,
             loading: PropTypes.bool,
+            loadingPosition: PropTypes.string,
             disabled: PropTypes.bool,
             variant: PropTypes.string,
             iconStrokeWidth: PropTypes.number,
@@ -56,6 +57,7 @@ export class Button extends mix(PureComponent).with(IdentifiableMixin) {
             leftSlot: undefined,
             rightSlot: undefined,
             loading: false,
+            loadingPosition: "center",
             disabled: false,
             variant: undefined,
             iconStrokeWidth: undefined,
@@ -152,8 +154,47 @@ export class Button extends mix(PureComponent).with(IdentifiableMixin) {
         ];
     };
 
+    _loadingStyle = () => {
+        return [
+            this.props.styles.container,
+            {
+                position: "absolute",
+                justifyContent: "center",
+                paddingHorizontal: 0,
+                paddingVertical: 0
+            },
+            this.props.loadingPosition === "right"
+                ? { right: 15 }
+                : this.props.loadingPosition === "left"
+                ? { left: 15 }
+                : {}
+        ];
+    };
+
     _renderLoading() {
-        return <ActivityIndicator style={this.props.styles.container} color="#ffffff" />;
+        switch (this.props.loadingPosition) {
+            case "left":
+                return (
+                    <>
+                        <ActivityIndicator style={this._loadingStyle()} color="#ffffff" />
+                        <Text style={[this._textStyle()]}>{this.props.text}</Text>
+                    </>
+                );
+            case "right":
+                return (
+                    <>
+                        <Text style={[this._textStyle()]}>{this.props.text}</Text>
+                        <ActivityIndicator style={this._loadingStyle()} color="#ffffff" />
+                    </>
+                );
+            case "center":
+            default:
+                return (
+                    <>
+                        <ActivityIndicator style={this._loadingStyle()} color="#ffffff" />
+                    </>
+                );
+        }
     }
 
     _renderLeft() {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | The loading indicator by default still renders in the center (making the text disappear). Alternatively, `loadingPosition=left` and `loadingPosition=right` can be used to display the loading indicator at the left or right of the text, respectively. |
| Animated GIF |  ![button-loaders](https://user-images.githubusercontent.com/16060539/135624549-d849b2dd-3713-4303-a781-92094156ebee.gif) |

