### PR TITLE
Keyboard: special chars with emojis fix

### DIFF
--- a/react/components/molecules/keyboard/keyboard.js
+++ b/react/components/molecules/keyboard/keyboard.js
@@ -99,7 +99,7 @@ export class Keyboard extends Component {
     };
 
     _specialChars = () => {
-        return this.props.supportedCharacters.match(/[^a-zA-Z\d:]/g);
+        return [...this.props.supportedCharacters.replace(/[a-zA-Z\d:]/g, "")];
     };
 
     _hasSpecialChars = () => {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | - Using proper replace for extracting special chars as previously it was being extracted with regex and we were getting unicoded strigs of chars in case of special chars being unicode chars like emojis. |
| Animated GIF | Below |

### Before
![image](https://user-images.githubusercontent.com/24736423/135660247-e5db7132-6c17-4ce2-9432-bcadee9094da.png)

### After
![image](https://user-images.githubusercontent.com/24736423/135660230-6a5d5309-b5c6-4d4e-b545-167f70eeff33.png)

