### PR TITLE
Keyboard: Using grapheme-splitter

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
         "@react-native-community/clipboard": "^1.5.1",
         "@react-native-picker/picker": "^1.16.1",
         "buffer": "^6.0.3",
+        "grapheme-splitter": "^1.0.4",
         "js-base64": "^3.6.1",
         "react": "^17.0.1",
         "react-native": "^0.63.4",

--- a/react/components/molecules/keyboard/keyboard.js
+++ b/react/components/molecules/keyboard/keyboard.js
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 import { Animated, StyleSheet, View, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 
+import GraphemeSplitter from "grapheme-splitter";
+
 import { Button } from "../../atoms";
 
 export class Keyboard extends Component {
@@ -99,7 +101,9 @@ export class Keyboard extends Component {
     };
 
     _specialChars = () => {
-        return [...this.props.supportedCharacters.replace(/[a-zA-Z\d:]/g, "")];
+        const specialCharsString = this.props.supportedCharacters.replace(/[a-zA-Z\d:]/g, "");
+        const stringSplitter = new GraphemeSplitter();
+        return stringSplitter.splitGraphemes(specialCharsString);
     };
 
     _hasSpecialChars = () => {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | We may encounter situations in which a special character is split the wrong way e.g `"☘️".split("")` splitting into `[ "☘", "️" ]`. This is not desirable as we would expect it to split into `["☘️"]`.  Besides, this can also have an undesired effect by having additional undesired keys in the keyboard. |
| Decisions | - Use [grapheme-splitter](https://github.com/orling/grapheme-splitter) library to split the list of supported special characters to the different keys as we would expect. |
| Animated GIF | Below |

### Before
![image](https://user-images.githubusercontent.com/24736423/136193237-c293d1cc-baf3-4483-90b6-82bbc9ba0c40.png)

### After
![image](https://user-images.githubusercontent.com/24736423/136193208-e38eec7b-5c61-4e2b-a268-d26145319b1d.png)


