### PR TITLE
#286: Enhance image inspecting experience with state-of-the-art zooming features #286

### DIFF
--- a/react/components/molecules/image-carrousel/image-carrousel.js
+++ b/react/components/molecules/image-carrousel/image-carrousel.js
@@ -256,8 +256,8 @@ export class ImageCarrousel extends PureComponent {
     };
 
     onFlingMovement = event => {
+        if (this.state.zoomed) return;
         if (event.nativeEvent.state === State.END) {
-            if (this.state.zoomed) return;
             this.setState({ visible: false });
         }
     };
@@ -294,6 +294,7 @@ export class ImageCarrousel extends PureComponent {
         return (
             <View style={styles.container}>
                 <Modal
+                    activeOpacity={0.3}
                     animationType="fade"
                     transparent={false}
                     visible={this.state.visible}
@@ -360,8 +361,10 @@ export class ImageCarrousel extends PureComponent {
                             />
                             {this.props.images.length > 1 && (
                                 <Text style={styles.title}>
-                                {`${this.state.selectedImage + 1} / ${this.props.images.length}`}
-                            </Text>
+                                    {`${this.state.selectedImage + 1} / ${
+                                        this.props.images.length
+                                    }`}
+                                </Text>
                             )}
                         </View>
                     </FlingGestureHandler>

--- a/react/components/molecules/image-carrousel/image-carrousel.js
+++ b/react/components/molecules/image-carrousel/image-carrousel.js
@@ -54,6 +54,9 @@ export class ImageCarrousel extends PureComponent {
 
         this.screenWidth = Dimensions.get("window").width;
         this.screenHeight = Dimensions.get("window").height;
+        this.fullZoomedInValue = 2;
+        this.fullZoomedOutValue = 1;
+        
         this.translatedX = 0;
         this.translatedXTreshold = 0;
         this.translatedY = 0;
@@ -213,7 +216,7 @@ export class ImageCarrousel extends PureComponent {
         this.setState({ zooming: true }, () => {
             Animated.parallel([
                 Animated.timing(this.state.baseScale, {
-                    toValue: 2,
+                    toValue: this.fullZoomedInValue,
                     duration: this.props.zoomAnimationDuration,
                     useNativeDriver: true
                 }),
@@ -237,7 +240,7 @@ export class ImageCarrousel extends PureComponent {
         this.setState({ zooming: true }, () => {
             Animated.parallel([
                 Animated.timing(this.state.baseScale, {
-                    toValue: 1,
+                    toValue: this.fullZoomedOutValue,
                     duration: this.props.zoomAnimationDuration,
                     useNativeDriver: true
                 }),

--- a/react/components/molecules/image-carrousel/image-carrousel.js
+++ b/react/components/molecules/image-carrousel/image-carrousel.js
@@ -130,7 +130,7 @@ export class ImageCarrousel extends PureComponent {
 
     reset() {
         this.setState({ zoomed: false });
-        this.state.baseScale.setValue(1);
+        this.state.baseScale.setValue(this.fullZoomedOutValue);
         this.state.translateX.setValue(0);
         this.state.translateY.setValue(0);
     }

--- a/react/components/molecules/image-carrousel/image-carrousel.js
+++ b/react/components/molecules/image-carrousel/image-carrousel.js
@@ -358,9 +358,11 @@ export class ImageCarrousel extends PureComponent {
                                 iconStrokeColor={"#ffffff"}
                                 onPress={this.onClosePress}
                             />
-                            <Text style={styles.title}>
+                            {this.props.images.length > 1 && (
+                                <Text style={styles.title}>
                                 {`${this.state.selectedImage + 1} / ${this.props.images.length}`}
                             </Text>
+                            )}
                         </View>
                     </FlingGestureHandler>
                 </Modal>

--- a/react/components/molecules/image-carrousel/image-carrousel.js
+++ b/react/components/molecules/image-carrousel/image-carrousel.js
@@ -14,6 +14,7 @@ import PropTypes from "prop-types";
 import {
     Directions,
     FlingGestureHandler,
+    GestureHandlerRootView,
     PanGestureHandler,
     ScrollView,
     State,
@@ -279,7 +280,7 @@ export class ImageCarrousel extends PureComponent {
                     duration: this.fullscreenContainerBackgroundColorAnimatedDuration,
                     useNativeDriver: false
                 })
-            ]).start(() => this.setState({ visible: false }));
+            ]).start(() => this.closeLigthBox());
         }
     };
 
@@ -337,75 +338,79 @@ export class ImageCarrousel extends PureComponent {
                     visible={this.state.visible}
                     onRequestClose={this.onBackButtonPress}
                 >
-                    <FlingGestureHandler
-                        direction={Directions.DOWN}
-                        onHandlerStateChange={this.onFlingMovement}
-                    >
-                        <Animated.View style={this._fullscreenContainerStyle()}>
-                            <ScrollView
-                                scrollEnabled={this.state.zooming || !this.state.zoomed}
-                                disableScrollViewPanResponder={this.state.zoomed}
-                                contentOffset={{ x: this.state.currentPagePosition, y: 0 }}
-                                style={styles.scrollView}
-                                contentContainerStyle={{
-                                    flexGrow: 1,
-                                    alignItems: "center",
-                                    justifyContent: "center"
-                                }}
-                                horizontal={true}
-                                pagingEnabled={true}
-                                showsHorizontalScrollIndicator={true}
-                                onScroll={this.onScroll}
-                            >
-                                {this.props.images.map((image, index) => (
-                                    <TapGestureHandler
-                                        key={index}
-                                        onHandlerStateChange={event =>
-                                            this.onImageDoubleTap(event, index)
-                                        }
-                                        numberOfTaps={2}
-                                    >
-                                        <Animated.Image
-                                            style={this._imageFullscreenStyle(image, index)}
-                                            resizeMode={this.props.resizeModeFullScreen}
-                                            source={this._imageSource(image)}
-                                        />
-                                    </TapGestureHandler>
-                                ))}
-                            </ScrollView>
-                            {this.state.zoomed && (
-                                <PanGestureHandler
-                                    onHandlerStateChange={this.onPanGestureEnd}
-                                    onGestureEvent={this.onPanGesture}
+                    <GestureHandlerRootView style={{ width: "100%", height: "100%" }}>
+                        <FlingGestureHandler
+                            direction={Directions.DOWN}
+                            onHandlerStateChange={this.onFlingMovement}
+                        >
+                            <Animated.View style={this._fullscreenContainerStyle()}>
+                                <ScrollView
+                                    scrollEnabled={this.state.zooming || !this.state.zoomed}
+                                    disableScrollViewPanResponder={this.state.zoomed}
+                                    contentOffset={{ x: this.state.currentPagePosition, y: 0 }}
+                                    style={styles.scrollView}
+                                    contentContainerStyle={{
+                                        flexGrow: 1,
+                                        alignItems: "center",
+                                        justifyContent: "center"
+                                    }}
+                                    horizontal={true}
+                                    pagingEnabled={true}
+                                    showsHorizontalScrollIndicator={true}
+                                    onScroll={this.onScroll}
                                 >
-                                    <TapGestureHandler
-                                        onHandlerStateChange={event => this.onImageDoubleTap(event)}
-                                        numberOfTaps={2}
+                                    {this.props.images.map((image, index) => (
+                                        <TapGestureHandler
+                                            key={index}
+                                            onHandlerStateChange={event =>
+                                                this.onImageDoubleTap(event, index)
+                                            }
+                                            numberOfTaps={2}
+                                        >
+                                            <Animated.Image
+                                                style={this._imageFullscreenStyle(image, index)}
+                                                resizeMode={this.props.resizeModeFullScreen}
+                                                source={this._imageSource(image)}
+                                            />
+                                        </TapGestureHandler>
+                                    ))}
+                                </ScrollView>
+                                {this.state.zoomed && (
+                                    <PanGestureHandler
+                                        onHandlerStateChange={this.onPanGestureEnd}
+                                        onGestureEvent={this.onPanGesture}
                                     >
-                                        <View style={styles.panResponderView} />
-                                    </TapGestureHandler>
-                                </PanGestureHandler>
-                            )}
-                            <ButtonIcon
-                                style={styles.buttonClose}
-                                icon={"close"}
-                                iconStrokeWidth={2}
-                                size={isTabletSize() ? 52 : 34}
-                                iconHeight={isTabletSize() ? 34 : 22}
-                                iconWidth={isTabletSize() ? 34 : 22}
-                                backgroundColor={"#000000"}
-                                iconStrokeColor={"#ffffff"}
-                                onPress={this.onClosePress}
-                            />
-                            {this.props.images.length > 1 && (
-                                <Text style={styles.title}>
-                                    {`${this.state.selectedImage + 1} / ${
-                                        this.props.images.length
-                                    }`}
-                                </Text>
-                            )}
-                        </Animated.View>
-                    </FlingGestureHandler>
+                                        <TapGestureHandler
+                                            onHandlerStateChange={event =>
+                                                this.onImageDoubleTap(event)
+                                            }
+                                            numberOfTaps={2}
+                                        >
+                                            <View style={styles.panResponderView} />
+                                        </TapGestureHandler>
+                                    </PanGestureHandler>
+                                )}
+                                <ButtonIcon
+                                    style={styles.buttonClose}
+                                    icon={"close"}
+                                    iconStrokeWidth={2}
+                                    size={isTabletSize() ? 52 : 34}
+                                    iconHeight={isTabletSize() ? 34 : 22}
+                                    iconWidth={isTabletSize() ? 34 : 22}
+                                    backgroundColor={"#000000"}
+                                    iconStrokeColor={"#ffffff"}
+                                    onPress={this.onClosePress}
+                                />
+                                {this.props.images.length > 1 && (
+                                    <Text style={styles.title}>
+                                        {`${this.state.selectedImage + 1} / ${
+                                            this.props.images.length
+                                        }`}
+                                    </Text>
+                                )}
+                            </Animated.View>
+                        </FlingGestureHandler>
+                    </GestureHandlerRootView>
                 </Modal>
             </View>
         );

--- a/react/components/molecules/image-carrousel/image-carrousel.js
+++ b/react/components/molecules/image-carrousel/image-carrousel.js
@@ -9,8 +9,6 @@ import {
     View,
     ViewPropTypes
 } from "react-native";
-import PropTypes from "prop-types";
-
 import {
     Directions,
     FlingGestureHandler,
@@ -20,9 +18,11 @@ import {
     State,
     TapGestureHandler
 } from "react-native-gesture-handler";
-
+import PropTypes from "prop-types";
 import { isTabletSize } from "ripe-commons-native";
-import { ButtonIcon } from "ripe-components-react-native";
+
+import { ButtonIcon } from "../../atoms/button-icon";
+
 export class ImageCarrousel extends PureComponent {
     static get propTypes() {
         return {
@@ -184,6 +184,24 @@ export class ImageCarrousel extends PureComponent {
         }
     };
 
+    onFlingMovement = event => {
+        if (this.state.zoomed) return;
+        if (event.nativeEvent.state === State.END) {
+            Animated.parallel([
+                Animated.timing(this.state.translateY, {
+                    toValue: this.fullscreenContainerTranslateYAnimationValue,
+                    duration: this.fullscreenContainerBackgroundColorAnimatedDuration,
+                    useNativeDriver: true
+                }),
+                Animated.timing(this.state.fullscreenContainerBackgroundColor, {
+                    toValue: this.fullscreenContainerBackgroundColorAnimated,
+                    duration: this.fullscreenContainerBackgroundColorAnimatedDuration,
+                    useNativeDriver: false
+                })
+            ]).start(() => this.closeLigthBox());
+        }
+    };
+
     _getTranslateX = (event, middle) => {
         const x = event.x;
         this.translatedXTreshold = this.screenWidth / 4;
@@ -264,24 +282,6 @@ export class ImageCarrousel extends PureComponent {
                 })
             ]).start(() => this.setState({ zooming: false, zoomed: false }));
         });
-    };
-
-    onFlingMovement = event => {
-        if (this.state.zoomed) return;
-        if (event.nativeEvent.state === State.END) {
-            Animated.parallel([
-                Animated.timing(this.state.translateY, {
-                    toValue: this.fullscreenContainerTranslateYAnimationValue,
-                    duration: this.fullscreenContainerBackgroundColorAnimatedDuration,
-                    useNativeDriver: true
-                }),
-                Animated.timing(this.state.fullscreenContainerBackgroundColor, {
-                    toValue: this.fullscreenContainerBackgroundColorAnimated,
-                    duration: this.fullscreenContainerBackgroundColorAnimatedDuration,
-                    useNativeDriver: false
-                })
-            ]).start(() => this.closeLigthBox());
-        }
     };
 
     _getAspectRatioHeight = imageIndex => {

--- a/react/components/molecules/image-carrousel/image-carrousel.js
+++ b/react/components/molecules/image-carrousel/image-carrousel.js
@@ -1,9 +1,9 @@
 import React, { PureComponent } from "react";
 import {
+    Animated,
     Dimensions,
     Image,
     Modal,
-    ScrollView,
     StyleSheet,
     Text,
     View,
@@ -11,16 +11,25 @@ import {
 } from "react-native";
 import PropTypes from "prop-types";
 
+import {
+    Directions,
+    FlingGestureHandler,
+    PanGestureHandler,
+    ScrollView,
+    State,
+    TapGestureHandler
+} from "react-native-gesture-handler";
+
 import { isTabletSize } from "ripe-commons-native";
-
-import { ButtonIcon } from "../../atoms";
-
+import { ButtonIcon } from "ripe-components-react-native";
 export class ImageCarrousel extends PureComponent {
     static get propTypes() {
         return {
+            images: PropTypes.array.isRequired,
             selectedImage: PropTypes.number,
+            zoomAnimationDuration: PropTypes.number,
+            translateAnimationDuration: PropTypes.number,
             resizeModeFullScreen: PropTypes.string,
-            images: PropTypes.array,
             onVisible: PropTypes.func,
             style: ViewPropTypes.style,
             styles: PropTypes.any
@@ -30,7 +39,9 @@ export class ImageCarrousel extends PureComponent {
     static get defaultProps() {
         return {
             selectedImage: 0,
-            resizeModeFullScreen: undefined,
+            zoomAnimationDuration: 200,
+            translateAnimationDuration: 200,
+            resizeModeFullScreen: "contain",
             images: [],
             onVisible: () => {},
             style: {},
@@ -42,11 +53,28 @@ export class ImageCarrousel extends PureComponent {
         super(props);
 
         this.screenWidth = Dimensions.get("window").width;
+        this.screenHeight = Dimensions.get("window").height;
+        this.translatedX = 0;
+        this.translatedXTreshold = 0;
+        this.translatedY = 0;
+        this.translatedYTreshold = 0;
+
+        this.imagesOriginalSizes = {};
 
         this.state = {
+            zoomed: false,
+            zooming: false,
             visible: false,
-            selectedImage: this.props.selectedImage
+            selectedImage: this.props.selectedImage,
+            baseScale: new Animated.Value(1),
+            translateX: new Animated.Value(0),
+            translateY: new Animated.Value(0),
+            imagesOriginalSizes: {}
         };
+    }
+
+    componentDidMount() {
+        this.setupImagesOriginalSizes();
     }
 
     setVisibility(value) {
@@ -56,6 +84,21 @@ export class ImageCarrousel extends PureComponent {
             },
             () => this.props.onVisible(value)
         );
+    }
+
+    setupImagesOriginalSizes() {
+        const imagesOriginalSizes = {};
+        this.props.images.forEach((image, index) => {
+            Image.getSize(image.uri, (width, height) => {
+                const aspectRatioHeight = this.screenWidth / (width / height);
+                imagesOriginalSizes[index] = {
+                    width: width,
+                    height: height,
+                    aspectRatioHeight: aspectRatioHeight
+                };
+            });
+        });
+        this.setState({ imagesOriginalSizes: imagesOriginalSizes });
     }
 
     open(imageIndex = 0) {
@@ -71,6 +114,14 @@ export class ImageCarrousel extends PureComponent {
 
     closeLigthBox() {
         this.setVisibility(false);
+        this.reset();
+    }
+
+    reset() {
+        this.setState({ zoomed: false });
+        this.state.baseScale.setValue(1);
+        this.state.translateX.setValue(0);
+        this.state.translateY.setValue(0);
     }
 
     onScroll = event => {
@@ -92,16 +143,148 @@ export class ImageCarrousel extends PureComponent {
         this.setVisibility(true);
     };
 
-    _imageSource = image => {
-        return image.uri ? { uri: image.uri } : image.src;
+    onPanGesture = event => {
+        if (!this.state.zoomed) return;
+        const dx = event.nativeEvent.translationX + this.translatedX;
+        const dy = event.nativeEvent.translationY + this.translatedY;
+        if (Math.abs(dx) < this.translatedXTreshold) {
+            this.state.translateX.setValue(dx);
+        }
+
+        if (Math.abs(dy) < this.translatedYTreshold) {
+            this.state.translateX.setValue(dy);
+        }
     };
 
-    _imageFullscreenStyle = image => {
+    onPanGestureEnd = event => {
+        if (event.nativeEvent.state === State.END) {
+            this.translatedX = this.state.translateX._value;
+        }
+    };
+
+    onImageDoubleTap = (event, index = null) => {
+        const imageindex = index || this.state.selectedImage;
+        if (event.nativeEvent.state === State.ACTIVE) {
+            if (this.state.zoomed) {
+                this._doubleTapZoomOut();
+            } else {
+                this._doubleTapZoomIn(event.nativeEvent, imageindex);
+            }
+        }
+    };
+
+    _getTranslateX = (event, middle) => {
+        const x = event.x;
+        this.translatedXTreshold = this.screenWidth / 4;
+        const touchMiddleDistance = x - middle;
+
+        const translateX =
+            Math.abs(touchMiddleDistance) > this.translatedXTreshold
+                ? this.translatedXTreshold
+                : touchMiddleDistance;
+        return x > middle ? -1 * Math.abs(translateX) : Math.abs(translateX);
+    };
+
+    _getTranslateY = (event, middle, imageHeight) => {
+        const y = event.y;
+
+        const imageScaledY = imageHeight * 2;
+        const touchMiddleDistance = middle - y;
+        this.translatedYTreshold =
+            imageScaledY > this.screenHeight ? (imageScaledY - this.screenHeight) / 2 : 0;
+        const translateY =
+            Math.abs(touchMiddleDistance) > this.translatedYTreshold
+                ? this.translatedYTreshold
+                : touchMiddleDistance;
+
+        return y > middle ? -1 * Math.abs(translateY) : Math.abs(translateY);
+    };
+
+    _doubleTapZoomIn = (event, imageIndex) => {
+        const imageHeight = this._getAspectRatioHeight(imageIndex);
+        const middleX = this.screenWidth / 2;
+        const middleY = imageHeight / 2;
+        const translateX = this._getTranslateX(event, middleX);
+        const translateY = this._getTranslateY(event, middleY, imageHeight);
+
+        this.translatedX = translateX;
+        this.translatedY = translateY;
+
+        this.setState({ zooming: true }, () => {
+            Animated.parallel([
+                Animated.timing(this.state.baseScale, {
+                    toValue: 2,
+                    duration: this.props.zoomAnimationDuration,
+                    useNativeDriver: true
+                }),
+                Animated.timing(this.state.translateX, {
+                    toValue: translateX,
+                    duration: this.props.translateAnimationDuration,
+                    useNativeDriver: true
+                }),
+                Animated.timing(this.state.translateY, {
+                    toValue: translateY,
+                    duration: this.props.translateAnimationDuration,
+                    useNativeDriver: true
+                })
+            ]).start(() => {
+                this.setState({ zooming: false, zoomed: true });
+            });
+        });
+    };
+
+    _doubleTapZoomOut = () => {
+        this.setState({ zooming: true }, () => {
+            Animated.parallel([
+                Animated.timing(this.state.baseScale, {
+                    toValue: 1,
+                    duration: this.props.zoomAnimationDuration,
+                    useNativeDriver: true
+                }),
+                Animated.timing(this.state.translateX, {
+                    toValue: 0,
+                    duration: this.props.zoomAnimationDuration,
+                    useNativeDriver: true
+                }),
+                Animated.timing(this.state.translateY, {
+                    toValue: 0,
+                    duration: this.props.zoomAnimationDuration,
+                    useNativeDriver: true
+                })
+            ]).start(() => this.setState({ zooming: false, zoomed: false }));
+        });
+    };
+
+    onFlingMovement = event => {
+        if (event.nativeEvent.state === State.END) {
+            if (this.state.zoomed) return;
+            this.setState({ visible: false });
+        }
+    };
+
+    _getAspectRatioHeight = imageIndex => {
+        return this.state.imagesOriginalSizes[imageIndex].aspectRatioHeight;
+    };
+
+    _imageSource = image => {
+        return image?.uri ? image : { uri: image };
+    };
+    _imageFullscreenStyle = (image, index) => {
         return [
             styles.imageFullscreen,
             {
-                resizeMode: this.props.resizeModeFullScreen,
-                width: this.screenWidth
+                width: this.screenWidth,
+                height: this.state.imagesOriginalSizes[index]
+                    ? this._getAspectRatioHeight(index)
+                    : "100%",
+                transform:
+                    this.state.selectedImage === index
+                        ? [
+                              { scale: this.state.baseScale },
+                              { translateX: this.state.translateX },
+                              { translateY: this.state.translateY }
+                          ]
+                        : []
             },
             image?.style
         ];
@@ -116,39 +299,70 @@ export class ImageCarrousel extends PureComponent {
                     visible={this.state.visible}
                     onRequestClose={this.onBackButtonPress}
                 >
-                    <View style={styles.fullscreenContainer}>
-                        <ScrollView
-                            contentOffset={{ x: this.state.currentPagePosition, y: 0 }}
-                            style={styles.scrollView}
-                            contentContainerStyle={{ flexGrow: 1 }}
-                            horizontal={true}
-                            pagingEnabled={true}
-                            showsHorizontalScrollIndicator={true}
-                            onScroll={this.onScroll}
-                        >
-                            {this.props.images.map((image, index) => (
-                                <Image
-                                    key={index}
-                                    style={this._imageFullscreenStyle(image)}
-                                    source={this._imageSource(image)}
-                                />
-                            ))}
-                        </ScrollView>
-                        <ButtonIcon
-                            style={styles.buttonClose}
-                            icon={"close"}
-                            iconStrokeWidth={2}
-                            size={isTabletSize() ? 52 : 34}
-                            iconHeight={isTabletSize() ? 34 : 22}
-                            iconWidth={isTabletSize() ? 34 : 22}
-                            backgroundColor={"#000000"}
-                            iconStrokeColor={"#ffffff"}
-                            onPress={this.onClosePress}
-                        />
-                        <Text style={styles.title}>
-                            {`${this.state.selectedImage + 1} / ${this.props.images.length}`}
-                        </Text>
-                    </View>
+                    <FlingGestureHandler
+                        direction={Directions.DOWN | Directions.UP}
+                        onHandlerStateChange={this.onFlingMovement}
+                    >
+                        <View style={styles.fullscreenContainer}>
+                            <ScrollView
+                                scrollEnabled={this.state.zooming || !this.state.zoomed}
+                                disableScrollViewPanResponder={this.state.zoomed}
+                                contentOffset={{ x: this.state.currentPagePosition, y: 0 }}
+                                style={styles.scrollView}
+                                contentContainerStyle={{
+                                    flexGrow: 1,
+                                    alignItems: "center",
+                                    justifyContent: "center"
+                                }}
+                                horizontal={true}
+                                pagingEnabled={true}
+                                showsHorizontalScrollIndicator={true}
+                                onScroll={this.onScroll}
+                            >
+                                {this.props.images.map((image, index) => (
+                                    <TapGestureHandler
+                                        onHandlerStateChange={event =>
+                                            this.onImageDoubleTap(event, index)
+                                        }
+                                        numberOfTaps={2}
+                                    >
+                                        <Animated.Image
+                                            style={this._imageFullscreenStyle(image, index)}
+                                            resizeMode={this.props.resizeModeFullScreen}
+                                            source={this._imageSource(image)}
+                                        />
+                                    </TapGestureHandler>
+                                ))}
+                            </ScrollView>
+                            {this.state.zoomed && (
+                                <PanGestureHandler
+                                    onHandlerStateChange={this.onPanGestureEnd}
+                                    onGestureEvent={this.onPanGesture}
+                                >
+                                    <TapGestureHandler
+                                        onHandlerStateChange={event => this.onImageDoubleTap(event)}
+                                        numberOfTaps={2}
+                                    >
+                                        <View style={styles.panResponderView} />
+                                    </TapGestureHandler>
+                                </PanGestureHandler>
+                            )}
+                            <ButtonIcon
+                                style={styles.buttonClose}
+                                icon={"close"}
+                                iconStrokeWidth={2}
+                                size={isTabletSize() ? 52 : 34}
+                                iconHeight={isTabletSize() ? 34 : 22}
+                                iconWidth={isTabletSize() ? 34 : 22}
+                                backgroundColor={"#000000"}
+                                iconStrokeColor={"#ffffff"}
+                                onPress={this.onClosePress}
+                            />
+                            <Text style={styles.title}>
+                                {`${this.state.selectedImage + 1} / ${this.props.images.length}`}
+                            </Text>
+                        </View>
+                    </FlingGestureHandler>
                 </Modal>
             </View>
         );
@@ -162,12 +376,16 @@ const styles = StyleSheet.create({
     scrollView: {
         flex: 1
     },
-    imageFullscreen: {
-        resizeMode: "contain"
-    },
     fullscreenContainer: {
         flex: 1,
+        alignItems: "center",
+        justifyContent: "center",
         backgroundColor: "#000000"
+    },
+    panResponderView: {
+        position: "absolute",
+        height: "100%",
+        width: "100%"
     },
     buttonClose: {
         position: "absolute",

--- a/react/components/molecules/image-carrousel/image-carrousel.js
+++ b/react/components/molecules/image-carrousel/image-carrousel.js
@@ -163,7 +163,7 @@ export class ImageCarrousel extends PureComponent {
         }
 
         if (Math.abs(dy) < this.translatedYTreshold) {
-            this.state.translateX.setValue(dy);
+            this.state.translateY.setValue(dy);
         }
     };
 

--- a/react/components/molecules/image-carrousel/image-carrousel.js
+++ b/react/components/molecules/image-carrousel/image-carrousel.js
@@ -62,7 +62,7 @@ export class ImageCarrousel extends PureComponent {
 
         this.fullZoomedInValue = 2;
         this.fullZoomedOutValue = 1;
-        
+
         this.translatedX = 0;
         this.translatedXTreshold = 0;
         this.translatedY = 0;

--- a/react/components/molecules/image-carrousel/image-carrousel.js
+++ b/react/components/molecules/image-carrousel/image-carrousel.js
@@ -359,6 +359,7 @@ export class ImageCarrousel extends PureComponent {
                             >
                                 {this.props.images.map((image, index) => (
                                     <TapGestureHandler
+                                        key={index}
                                         onHandlerStateChange={event =>
                                             this.onImageDoubleTap(event, index)
                                         }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-components-react-native/issues/286 |
| Decisions | - Using an overlay transparent `view` as a workaround to handle `panResponder` with a scrollView <br> - Calculate the `height` maintaining aspect ratio of the image to set that as a height value to stop the `image component` of occupying 100% of the height (that would difficult the task of knowing when the double-tap was outside of the image) <br> - Dismiss modal on Fling movement |
| Animated GIF | ![R4g2bWDcG3](https://user-images.githubusercontent.com/8842023/146162986-7b82afee-4698-472e-9dee-09d347f480f7.gif) <br> Dismiss on Fling: <br> ![MSpJJq7SsI](https://user-images.githubusercontent.com/8842023/146396437-22877578-f87d-4d32-86ba-b8b9fb142027.gif) |
