### PR TITLE
fix: apply padding horizontal to button group in profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Apply padding horizontal to button group in profile component
 
 ## [0.12.0] - 2021-12-10
 

--- a/react/components/organisms/profile/profile.js
+++ b/react/components/organisms/profile/profile.js
@@ -124,7 +124,7 @@ export class Profile extends Component {
             borderBottomRightRadius: 0,
             borderTopLeftRadius: 0,
             borderTopRightRadius: 0,
-            paddingLeft: 15
+            paddingHorizontal: 15
         };
     };
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Issue pointed out by @joamag<br>![image](https://user-images.githubusercontent.com/25725586/151532042-9c218392-6a2c-4ff6-930b-c730aa1f03c7.png) |
| Dependencies | -- |
| Decisions | - Applied `paddingHorizontal` to button group in profile component. |
| Animated GIF | ![image](https://user-images.githubusercontent.com/25725586/151532097-9bd15c5a-a35d-46a2-879b-b55cc31d0851.png)<br>![image](https://user-images.githubusercontent.com/25725586/151532138-3e3b82d4-39c6-4cf4-8856-1700d7eec431.png)|
