### PR TITLE
feat: add URL prefix to profile and made button padding similar to key-value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Apply padding horizontal to button group in profile component
+* Made button horizontal padding similar to the key-value padding
 
 ## [0.12.0] - 2021-12-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Added URL prefix for some fields of the profile component
 
 ### Changed
 

--- a/react/components/atoms/button/button.js
+++ b/react/components/atoms/button/button.js
@@ -264,7 +264,7 @@ const styles = StyleSheet.create({
         flexDirection: "row",
         justifyContent: "center",
         alignItems: "center",
-        paddingHorizontal: 16,
+        paddingHorizontal: 16
     },
     containerFlat: {
         backgroundColor: "#ffffff",

--- a/react/components/atoms/button/button.js
+++ b/react/components/atoms/button/button.js
@@ -264,7 +264,7 @@ const styles = StyleSheet.create({
         flexDirection: "row",
         justifyContent: "center",
         alignItems: "center",
-        paddingHorizontal: 8
+        paddingHorizontal: 16,
     },
     containerFlat: {
         backgroundColor: "#ffffff",

--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -15,6 +15,7 @@ export class KeyValues extends PureComponent {
                 PropTypes.shape({
                     key: PropTypes.string.isRequired,
                     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+                    valueComponent: PropTypes.object,
                     keyColor: PropTypes.string,
                     valueColor: PropTypes.string,
                     border: PropTypes.string,

--- a/react/components/organisms/profile/profile.js
+++ b/react/components/organisms/profile/profile.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { ScrollView, Share, StyleSheet, View } from "react-native";
+import { Platform, ScrollView, Share, StyleSheet, View } from "react-native";
 import PropTypes from "prop-types";
 
 import { baseStyles } from "../../../util";
@@ -85,15 +85,39 @@ export class Profile extends Component {
             },
             {
                 key: "Github",
-                value: this.props.account.meta?.github_username
+                value: this.props.account.meta?.github_username,
+                valueComponent: (
+                    <View style={styles.keyValue}>
+                        <Text style={styles.keyPrefixValue}>{"github.com/"}</Text>
+                        <Text style={styles.keyValueValue}>
+                            {this.props.account.meta?.github_username}
+                        </Text>
+                    </View>
+                )
             },
             {
                 key: "Twitter",
-                value: this.props.account.meta?.twitter_username
+                value: this.props.account.meta?.twitter_username,
+                valueComponent: (
+                    <View style={styles.keyValue}>
+                        <Text style={styles.keyPrefixValue}>{"twitter.com/"}</Text>
+                        <Text style={styles.keyValueValue}>
+                            {this.props.account.meta?.twitter_username}
+                        </Text>
+                    </View>
+                )
             },
             {
                 key: "Linkedin",
-                value: this.props.account.meta?.linkedin_username
+                value: this.props.account.meta?.linkedin_username,
+                valueComponent: (
+                    <View style={styles.keyValue}>
+                        <Text style={styles.keyPrefixValue}>{"linkedin.com/in/"}</Text>
+                        <Text style={styles.keyValueValue}>
+                            {this.props.account.meta?.linkedin_username}
+                        </Text>
+                    </View>
+                )
             }
         ].filter(v => Boolean(v));
     };
@@ -244,6 +268,20 @@ const styles = StyleSheet.create({
     },
     detailsTitleText: {
         fontFamily: baseStyles.FONT
+    },
+    keyValue: {
+        flexDirection: "row"
+    },
+    keyPrefixValue: {
+        color: "#9a9a9a",
+        fontSize: 16,
+        lineHeight: 18
+    },
+    keyValueValue: {
+        marginTop: Platform.OS === "ios" ? 4 : 0,
+        fontFamily: baseStyles.FONT,
+        fontSize: 16,
+        lineHeight: 18
     },
     buttons: {
         height: "100%",


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | -  * Added URL prefix for some fields of the profile component<br>- Made button horizontal padding similar to the key-value padding|
| Animated GIF | ![image](https://user-images.githubusercontent.com/25725586/151543696-44f93061-bd62-4ae2-a7ae-6a4871f66ccb.png)|
