### PR TITLE
#286: Support for modal-like image viewing and zooming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Added URL prefix for some fields of the profile component
-* Support for modal-like image viewing and zooming [#286](https://github.com/ripe-tech/ripe-components-react-native/issues/286)
+* Support for modal-like image viewing and zooming - [#286](https://github.com/ripe-tech/ripe-components-react-native/issues/286)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Added URL prefix for some fields of the profile component
+* Support for modal-like image viewing and zooming [#286](https://github.com/ripe-tech/ripe-components-react-native/issues/286)
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
         "react-native": "^0.63.4",
         "react-native-device-info": "^8.0.1",
         "react-native-document-picker": "^5.0.0",
+        "react-native-gesture-handler": "^2.1.0",
         "react-native-image-picker": "^4.0.3",
         "react-native-linear-gradient": "^2.5.6",
         "react-native-picker-select": "^8.0.4",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "react-native": "^0.63.4",
         "react-native-device-info": "^8.0.1",
         "react-native-document-picker": "^5.0.0",
-        "react-native-gesture-handler": "^2.1.0",
+        "react-native-gesture-handler": "^2.2.0",
         "react-native-image-picker": "^4.0.3",
         "react-native-linear-gradient": "^2.5.6",
         "react-native-picker-select": "^8.0.4",

--- a/react/components/atoms/lightbox/lightbox.js
+++ b/react/components/atoms/lightbox/lightbox.js
@@ -171,8 +171,8 @@ export class Lightbox extends PureComponent {
             this.resetTranslation();
             this.baseScale.setValue(this.lastScale);
             this.scaleRate.setValue(1);
-            this.translatedXTreshold = this.screenWidth / this._sanatizeFloat(this.lastScale * 2);
-            this.translatedYTreshold = this.screenHeight / this._sanatizeFloat(this.lastScale * 2);
+            this.translatedXTreshold = (this.screenWidth * this.lastScale - this.screenWidth) / 4;
+            this.translatedYTreshold = (this.screenHeight * this.lastScale - this.screenHeight) / 4;
         }
     };
 

--- a/react/components/atoms/lightbox/lightbox.js
+++ b/react/components/atoms/lightbox/lightbox.js
@@ -104,7 +104,6 @@ export class Lightbox extends PureComponent {
         this.baseScale.setValue(1);
         this.state.translateX.setValue(0);
         this.state.translateY.setValue(0);
-        this.state.containerBackgroundColor.setValue(0);
     }
 
     resetTranslation = () => {

--- a/react/components/atoms/lightbox/lightbox.js
+++ b/react/components/atoms/lightbox/lightbox.js
@@ -69,17 +69,17 @@ export class Lightbox extends PureComponent {
         this.translatedY = 0;
         this.translatedYTreshold = 0;
 
+        this.translateX = new Animated.Value(0),
+        this.translateY = new Animated.Value(0),
         this.baseScale = new Animated.Value(1);
         this.scaleRate = new Animated.Value(1);
+        this.scale = Animated.multiply(this.baseScale, this.scaleRate),
         this.lastScale = 1;
 
         this.state = {
             zoomed: false,
             zooming: false,
-            visible: this.props.visible,
-            scale: Animated.multiply(this.baseScale, this.scaleRate),
-            translateX: new Animated.Value(0),
-            translateY: new Animated.Value(0)
+            visible: this.props.visible
         };
     }
 
@@ -101,18 +101,18 @@ export class Lightbox extends PureComponent {
         this.setState({ zoomed: false });
         this.scaleRate.setValue(1);
         this.baseScale.setValue(1);
-        this.state.translateX.setValue(0);
-        this.state.translateY.setValue(0);
+        this.translateX.setValue(0);
+        this.translateY.setValue(0);
     }
 
     resetTranslation = () => {
         Animated.parallel([
-            Animated.timing(this.state.translateX, {
+            Animated.timing(this.translateX, {
                 toValue: 0,
                 duration: this.props.zoomAnimationDuration,
                 useNativeDriver: true
             }),
-            Animated.timing(this.state.translateY, {
+            Animated.timing(this.translateY, {
                 toValue: 0,
                 duration: this.props.zoomAnimationDuration,
                 useNativeDriver: true
@@ -136,24 +136,24 @@ export class Lightbox extends PureComponent {
     };
 
     onPanGesture = event => {
-        if (this.state.scale._value === 1 || !this.state.zoomed) return;
+        if (this.scale._value === 1 || !this.state.zoomed) return;
 
         const dx = event.nativeEvent.translationX + this.translatedX;
         const dy = event.nativeEvent.translationY + this.translatedY;
 
         if (Math.abs(dx) < this.translatedXTreshold) {
-            this.state.translateX.setValue(dx);
+            this.translateX.setValue(dx);
         }
         if (Math.abs(dy) < this.translatedYTreshold) {
-            this.state.translateY.setValue(dy);
+            this.translateY.setValue(dy);
         }
     };
 
     onPanGestureEnd = event => {
         if (event.nativeEvent.state !== State.END) return;
 
-        this.translatedX = this.state.translateX._value;
-        this.translatedY = this.state.translateY._value;
+        this.translatedX = this.translateX._value;
+        this.translatedY = this.translateY._value;
     };
 
     onPinchGesture = event => {
@@ -203,12 +203,12 @@ export class Lightbox extends PureComponent {
                     duration: this.props.zoomAnimationDuration,
                     useNativeDriver: true
                 }),
-                Animated.timing(this.state.translateX, {
+                Animated.timing(this.translateX, {
                     toValue: translateX,
                     duration: this.props.translateAnimationDuration,
                     useNativeDriver: true
                 }),
-                Animated.timing(this.state.translateY, {
+                Animated.timing(this.translateY, {
                     toValue: translateY,
                     duration: this.props.translateAnimationDuration,
                     useNativeDriver: true
@@ -236,12 +236,12 @@ export class Lightbox extends PureComponent {
                     duration: this.props.zoomAnimationDuration,
                     useNativeDriver: true
                 }),
-                Animated.timing(this.state.translateX, {
+                Animated.timing(this.translateX, {
                     toValue: 0,
                     duration: this.props.zoomAnimationDuration,
                     useNativeDriver: true
                 }),
-                Animated.timing(this.state.translateY, {
+                Animated.timing(this.translateY, {
                     toValue: 0,
                     duration: this.props.zoomAnimationDuration,
                     useNativeDriver: true
@@ -322,9 +322,9 @@ export class Lightbox extends PureComponent {
             {
                 resizeMode: this.props.resizeModeFullScreen,
                 transform: [
-                    { scale: this.state.scale },
-                    { translateX: this.state.translateX },
-                    { translateY: this.state.translateY }
+                    { scale: this.scale },
+                    { translateX: this.translateX },
+                    { translateY: this.translateY }
                 ]
             }
         ];

--- a/react/components/atoms/lightbox/lightbox.js
+++ b/react/components/atoms/lightbox/lightbox.js
@@ -2,7 +2,6 @@ import React, { PureComponent } from "react";
 import { Animated, Dimensions, Image, Modal, StyleSheet, View, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 import {
-    GestureHandlerRootView,
     PanGestureHandler,
     PinchGestureHandler,
     State,

--- a/react/components/atoms/lightbox/lightbox.js
+++ b/react/components/atoms/lightbox/lightbox.js
@@ -116,7 +116,10 @@ export class Lightbox extends PureComponent {
                 duration: this.props.zoomAnimationDuration,
                 useNativeDriver: true
             })
-        ]).start();
+        ]).start(() => {
+            this.translatedX = 0;
+            this.translatedY = 0;
+        });
     };
 
     onBackButtonPress = () => {
@@ -163,6 +166,7 @@ export class Lightbox extends PureComponent {
 
     onPinchGestureEnd = event => {
         if (event.nativeEvent.oldState !== State.ACTIVE) return;
+
         this.resetTranslation();
         this.baseScale.setValue(this.lastScale);
         this.scaleRate.setValue(1);

--- a/react/components/atoms/lightbox/lightbox.js
+++ b/react/components/atoms/lightbox/lightbox.js
@@ -154,7 +154,6 @@ export class Lightbox extends PureComponent {
     onPinchGesture = event => {
         const pinchScale = event.nativeEvent.scale;
         const scale = this.baseScale._value * pinchScale;
-
         if (scale < 1 || scale > 2) return;
 
         this.scaleRate.setValue(pinchScale);

--- a/react/components/atoms/lightbox/lightbox.js
+++ b/react/components/atoms/lightbox/lightbox.js
@@ -259,36 +259,50 @@ export class Lightbox extends PureComponent {
         return this.props.uri ? { uri: this.props.uri } : this.props.src;
     };
 
-    /**
-     * gets the Y coordinate to zoom in to.
+     /**
+     * Gets the Y coordinate to zoom in to when double tapping
+     * the image. It takes into account the threshold so that the
+     * image does not move outside its limits.
      *
-     * @param {Object} event The double tap event
+     * @param {Object} event The double tap event.
      */
+
     _getDoubleTapZoomInTranslateY = event => {
         const y = event.y;
         const middle = this.screenHeight / this.fullZoomedInValue;
         const touchMiddleDistance = middle - y;
-
-        // if the distance of the coordinate is greater than the translate treshold
-        // then assume the treshold value as the X coordinate to zoom in to
         const translateY = Math.min(this.translatedYTreshold, Math.abs(touchMiddleDistance));
         return y > middle ? -1 * translateY : translateY;
     };
 
     /**
-     * gets the X coordinate to zoom in to.
+     * Gets the X coordinate to zoom in to when double tapping
+     * the image. It takes into account the threshold so that the
+     * image does not move outside its limits.
      *
-     * @param {Object} event The double tap event
+     * @param {Object} event The double tap event.
      */
     _getDoubleTapZoomInTranslateX = event => {
         const x = event.x;
         const middle = this.screenWidth / this.fullZoomedInValue;
         const touchMiddleDistance = x - middle;
-
-        // if the distance of the coordinate is greater than the translate treshold
-        // then assume the treshold value as the X coordinate to zoom in to
         const translateX = Math.min(this.translatedXTreshold, Math.abs(touchMiddleDistance));
         return x > middle ? -1 * translateX : translateX;
+    };
+
+    /**
+     * Determines how much space is available after translation
+     * until it reaches the end of the scaled image.
+     *
+     * @param {Number} scale Current scale value of the image.
+     */
+     _setTranslateTresholds = scale => {
+        const scaledHeight = this.screenHeight * scale;
+        const scaledWidth = this.screenWidth * scale;
+
+        const scaleDivisor = scale * 2;
+        this.translatedXTreshold = (scaledWidth - this.screenWidth) / scaleDivisor;
+        this.translatedYTreshold = (scaledHeight - this.screenHeight) / scaleDivisor;
     };
 
     _imageStyle = () => {
@@ -307,7 +321,6 @@ export class Lightbox extends PureComponent {
         return [
             styles.imageFullscreen,
             {
-                width: "100%",
                 resizeMode: this.props.resizeModeFullScreen,
                 transform: [
                     { scale: this.state.scale },
@@ -316,21 +329,6 @@ export class Lightbox extends PureComponent {
                 ]
             }
         ];
-    };
-
-    /**
-     * determines how much space is available after translation
-     * until reach the end of the scaled "image".
-     *
-     * @param {Float} scale Current scale value of the image
-     */
-    _setTranslateTresholds = scale => {
-        const scaledHeight = this.screenHeight * scale;
-        const scaledWidth = this.screenWidth * scale;
-
-        const scaleDivisor = scale * 2;
-        this.translatedXTreshold = (scaledWidth - this.screenWidth) / scaleDivisor;
-        this.translatedYTreshold = (scaledHeight - this.screenHeight) / scaleDivisor;
     };
 
     render() {
@@ -390,7 +388,8 @@ export class Lightbox extends PureComponent {
 
 const styles = StyleSheet.create({
     imageFullscreen: {
-        flex: 1
+        flex: 1,
+        width: "100%"
     },
     fullscreenContainer: {
         flex: 1,

--- a/react/components/atoms/lightbox/lightbox.js
+++ b/react/components/atoms/lightbox/lightbox.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from "react";
 import { Animated, Dimensions, Image, Modal, StyleSheet, View, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 import {
+    GestureHandlerRootView,
     PanGestureHandler,
     PinchGestureHandler,
     State,
@@ -69,11 +70,11 @@ export class Lightbox extends PureComponent {
         this.translatedY = 0;
         this.translatedYTreshold = 0;
 
-        this.translateX = new Animated.Value(0),
-        this.translateY = new Animated.Value(0),
+        this.translateX = new Animated.Value(0);
+        this.translateY = new Animated.Value(0);
         this.baseScale = new Animated.Value(1);
         this.scaleRate = new Animated.Value(1);
-        this.scale = Animated.multiply(this.baseScale, this.scaleRate),
+        this.scale = Animated.multiply(this.baseScale, this.scaleRate);
         this.lastScale = 1;
 
         this.state = {
@@ -268,10 +269,10 @@ export class Lightbox extends PureComponent {
 
     _getDoubleTapZoomInTranslateY = event => {
         const y = event.y;
-        const middle = this.screenHeight / this.fullZoomedInValue;
-        const touchMiddleDistance = middle - y;
+        const middleY = this.screenHeight / 2;
+        const touchMiddleDistance = middleY - y;
         const translateY = Math.min(this.translatedYTreshold, Math.abs(touchMiddleDistance));
-        return y > middle ? -1 * translateY : translateY;
+        return y > middleY ? -1 * translateY : translateY;
     };
 
     /**
@@ -283,10 +284,10 @@ export class Lightbox extends PureComponent {
      */
     _getDoubleTapZoomInTranslateX = event => {
         const x = event.x;
-        const middle = this.screenWidth / this.fullZoomedInValue;
-        const touchMiddleDistance = x - middle;
+        const middleX = this.screenWidth / 2;
+        const touchMiddleDistance = x - middleX;
         const translateX = Math.min(this.translatedXTreshold, Math.abs(touchMiddleDistance));
-        return x > middle ? -1 * translateX : translateX;
+        return x > middleX ? -1 * translateX : translateX;
     };
 
     /**
@@ -342,43 +343,45 @@ export class Lightbox extends PureComponent {
                     visible={this.state.visible}
                     onRequestClose={this.onBackButtonPress}
                 >
-                    <Animated.View style={styles.fullscreenContainer}>
-                        <PanGestureHandler
-                            minPointers={1}
-                            maxPointers={1}
-                            onHandlerStateChange={this.onPanGestureEnd}
-                            onGestureEvent={this.onPanGesture}
-                        >
-                            <TapGestureHandler
-                                onHandlerStateChange={this.onDoubleTap}
-                                numberOfTaps={2}
+                    <GestureHandlerRootView style={styles.gestureHandlerRootView}>
+                        <Animated.View style={styles.fullscreenContainer}>
+                            <PanGestureHandler
+                                minPointers={1}
+                                maxPointers={1}
+                                onHandlerStateChange={this.onPanGestureEnd}
+                                onGestureEvent={this.onPanGesture}
                             >
-                                <PinchGestureHandler
-                                    onGestureEvent={this.onPinchGesture}
-                                    onHandlerStateChange={this.onPinchGestureEnd}
+                                <TapGestureHandler
+                                    onHandlerStateChange={this.onDoubleTap}
+                                    numberOfTaps={2}
                                 >
-                                    <Animated.Image
-                                        resizeMode={this.props.resizeModeFullScreen}
-                                        style={this._imageFullscreenStyle()}
-                                        source={this._imageSource()}
-                                    />
-                                </PinchGestureHandler>
-                            </TapGestureHandler>
-                        </PanGestureHandler>
-                        {this.props.closeButton && (
-                            <ButtonIcon
-                                icon={"close"}
-                                onPress={this.onClosePress}
-                                style={styles.buttonClose}
-                                iconStrokeWidth={2}
-                                size={isTabletSize() ? 52 : 34}
-                                iconHeight={isTabletSize() ? 34 : 22}
-                                iconWidth={isTabletSize() ? 34 : 22}
-                                backgroundColor={"#000000"}
-                                iconStrokeColor={"#ffffff"}
-                            />
-                        )}
-                    </Animated.View>
+                                    <PinchGestureHandler
+                                        onGestureEvent={this.onPinchGesture}
+                                        onHandlerStateChange={this.onPinchGestureEnd}
+                                    >
+                                        <Animated.Image
+                                            resizeMode={this.props.resizeModeFullScreen}
+                                            style={this._imageFullscreenStyle()}
+                                            source={this._imageSource()}
+                                        />
+                                    </PinchGestureHandler>
+                                </TapGestureHandler>
+                            </PanGestureHandler>
+                            {this.props.closeButton && (
+                                <ButtonIcon
+                                    icon={"close"}
+                                    onPress={this.onClosePress}
+                                    style={styles.buttonClose}
+                                    iconStrokeWidth={2}
+                                    size={isTabletSize() ? 52 : 34}
+                                    iconHeight={isTabletSize() ? 34 : 22}
+                                    iconWidth={isTabletSize() ? 34 : 22}
+                                    backgroundColor={"#000000"}
+                                    iconStrokeColor={"#ffffff"}
+                                />
+                            )}
+                        </Animated.View>
+                    </GestureHandlerRootView>
                 </Modal>
             </View>
         );
@@ -389,6 +392,10 @@ const styles = StyleSheet.create({
     imageFullscreen: {
         flex: 1,
         width: "100%"
+    },
+    gestureHandlerRootView: {
+        width: "100%",
+        height: "100%"
     },
     fullscreenContainer: {
         flex: 1,

--- a/react/components/atoms/lightbox/lightbox.js
+++ b/react/components/atoms/lightbox/lightbox.js
@@ -171,7 +171,10 @@ export class Lightbox extends PureComponent {
     onPinchGestureEnd = event => {
         if (event.nativeEvent.oldState !== State.ACTIVE) return;
 
+        // as the pinch is always centered we reset translation
+        // as housekeeping
         this.resetTranslation();
+
         this.baseScale.setValue(this.lastScale);
         this.scaleRate.setValue(1);
         this._setTranslateTresholds(this.lastScale);

--- a/react/components/atoms/lightbox/lightbox.js
+++ b/react/components/atoms/lightbox/lightbox.js
@@ -175,12 +175,12 @@ export class Lightbox extends PureComponent {
     };
 
     onDoubleTap = event => {
-        if (event.nativeEvent.state === State.ACTIVE) {
-            if (!this.state.zoomed) {
-                this._doubleTapZoomIn(event.nativeEvent);
-            } else {
-                this._doubleTapZoomOut();
-            }
+        if (event.nativeEvent.state !== State.ACTIVE) return;
+
+        if (!this.state.zoomed) {
+            this._doubleTapZoomIn(event.nativeEvent);
+        } else {
+            this._doubleTapZoomOut();
         }
     };
 

--- a/react/components/atoms/lightbox/lightbox.js
+++ b/react/components/atoms/lightbox/lightbox.js
@@ -259,7 +259,7 @@ export class Lightbox extends PureComponent {
         return this.props.uri ? { uri: this.props.uri } : this.props.src;
     };
 
-     /**
+    /**
      * Gets the Y coordinate to zoom in to when double tapping
      * the image. It takes into account the threshold so that the
      * image does not move outside its limits.
@@ -296,7 +296,7 @@ export class Lightbox extends PureComponent {
      *
      * @param {Number} scale Current scale value of the image.
      */
-     _setTranslateTresholds = scale => {
+    _setTranslateTresholds = scale => {
         const scaledHeight = this.screenHeight * scale;
         const scaledWidth = this.screenWidth * scale;
 

--- a/react/components/atoms/lightbox/lightbox.js
+++ b/react/components/atoms/lightbox/lightbox.js
@@ -330,6 +330,8 @@ export class Lightbox extends PureComponent {
                     <GestureHandlerRootView style={{ width: "100%", height: "100%" }}>
                         <Animated.View style={styles.fullscreenContainer}>
                             <PanGestureHandler
+                                minPointers={1}
+                                maxPointers={1}
                                 onHandlerStateChange={this.onPanGestureEnd}
                                 onGestureEvent={this.onPanGesture}
                             >


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-components-react-native/issues/286 |
| Decisions | Double-tap zoom <br> Pinch zoom <br> Translate to the "edge" while zoomed in <br>|
| Animated GIF | <br> IOS: <br> ![2P5v4m5Kna](https://user-images.githubusercontent.com/8842023/151563818-61198bb9-af0f-4bf8-a8e8-4345539a68b3.gif) <br> Android: <br> ![HfaiLkN0I1](https://user-images.githubusercontent.com/8842023/151953152-c1f82808-cbd7-4e28-95a0-cd726360522b.gif)|
