### PR TITLE
fix: remove margin top for some key values in profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Remove margin for iOS for profile specific key values
 
 ## [0.15.0] - 2022-02-04
 

--- a/react/components/organisms/profile/profile.js
+++ b/react/components/organisms/profile/profile.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Platform, ScrollView, Share, StyleSheet, View } from "react-native";
+import { ScrollView, Share, StyleSheet, View } from "react-native";
 import PropTypes from "prop-types";
 
 import { baseStyles } from "../../../util";
@@ -278,7 +278,7 @@ const styles = StyleSheet.create({
         lineHeight: 18
     },
     keyValueValue: {
-        marginTop: Platform.OS === "ios" ? 4 : 0,
+        marginTop: 0,
         fontFamily: baseStyles.FONT,
         fontSize: 16,
         lineHeight: 18


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Issue found by @joamag where the links in the profiles had misaligned text<br>![imagem](https://user-images.githubusercontent.com/25725586/152765964-b940ba70-8d2b-4bf2-aa59-db13c9ca3dbe.png)|
| Dependencies | |
| Decisions | - Remove margin top only for iOS |
| Animated GIF | <img width="602" alt="imagem" src="https://user-images.githubusercontent.com/25725586/152765921-f61211ae-8d5b-4bc9-b94e-2088c01146f2.png">|
