### PR TITLE
version: 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+*
+
+### Changed
+
+*
+
+### Fixed
+
+*
+
+## [0.16.0] - 2022-02-11
+
+### Added
+
 * Added `source` prop to `Lightbox`
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-components-react-native",
-    "version": "0.15.0",
+    "version": "0.16.0",
     "description": "RIPE Components for React Native",
     "keywords": [
         "components",


### PR DESCRIPTION
### Added

* Added `source` prop to `Lightbox`

### Changed
* Added new variant to `TabsText` and `ButtonTabText` to reflect the new design - [ripe-robin-revamp/#315](https://github.com/ripe-tech/ripe-robin-revamp/issues/315)
* Scroll on tab selected in `TabsText` now tries to show all tabs next to the one selected - [ripe-robin-revamp/#315](https://github.com/ripe-tech/ripe-robin-revamp/issues/315)

### Fixed
* Remove margin for iOS for profile specific key values
* Box shadow mismatch between iOS and Android for `Item`