### PR TITLE
fix: remove node 15 from github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        node-version: [12, 13, 14, 15, 16]
+        node-version: [12, 13, 14, 16]
     runs-on: ubuntu-latest
     container: node:${{ matrix.node-version }}
     steps:


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Fix failing CI |
| Dependencies | -- |
| Decisions | - The error was only happening in node 15. Since it is not LTS and dependencies do not support it, it is better to be removed.<br>![imagem](https://user-images.githubusercontent.com/25725586/154065454-484439e1-714a-41da-bb2a-83218c1cd846.png) |
| Animated GIF | -- |
