### PR TITLE
fix: use index of current route to choose the selected tab in `Tabs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* Use index of current route to choose the selected tab in `Tabs` component
+* Use index of current route to choose the selected tab in `Tabs` component - [#301](https://github.com/ripe-tech/ripe-components-react-native/issues/301)
 
 ## [0.18.0] - 2022-02-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Use index of current route to choose the selected tab in `Tabs` component
 
 ## [0.18.0] - 2022-02-21
 

--- a/react/components/molecules/tabs/tabs.js
+++ b/react/components/molecules/tabs/tabs.js
@@ -45,9 +45,7 @@ export class Tabs extends PureComponent {
 
     constructor(props) {
         super(props);
-
         const currentTab = this.props.state.index;
-
         this.state = {
             animatedBarWidth: undefined,
             animatedBarOffset: undefined,

--- a/react/components/molecules/tabs/tabs.js
+++ b/react/components/molecules/tabs/tabs.js
@@ -26,6 +26,7 @@ export class Tabs extends PureComponent {
                     props: PropTypes.object
                 })
             ),
+            selectedTab: PropTypes.number,
             hasAnimation: PropTypes.bool,
             style: ViewPropTypes.style,
             styles: PropTypes.any
@@ -35,6 +36,7 @@ export class Tabs extends PureComponent {
     static get defaultProps() {
         return {
             tabs: [],
+            selectedTab: undefined,
             hasAnimation: true,
             style: {},
             styles: styles
@@ -44,10 +46,12 @@ export class Tabs extends PureComponent {
     constructor(props) {
         super(props);
 
+        const currentTab = this.props.state.index;
+
         this.state = {
             animatedBarWidth: undefined,
             animatedBarOffset: undefined,
-            selectedTab: 2
+            selectedTab: props.selectedTab === undefined ? currentTab : props.selectedTab
         };
         this.tabLayouts = {};
     }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-components-react-native/issues/301 |
| Dependencies | -- |
| Decisions | - Use index of current route to choose the selected tab in `Tabs`|
| Animated GIF | -- |
