### PR TITLE
fix: set of fixes in several components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Use the same margin horizontal in `Item` as the one being used in other components
+* Align expand buttons in `KeyValues` to the center in tablet screens 
 
 ## [0.18.0] - 2022-02-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Use the same margin horizontal in `Item` as the one being used in other components
-* Align expand buttons in `KeyValues` to the center in tablet screens 
+* Align expand buttons in `KeyValues` to the center in tablet screens
+* Align images in chat to the left and fix text wrap
 
 ## [0.18.0] - 2022-02-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Use the same margin horizontal in `Item` as the one being used in other components
 
 ## [0.18.0] - 2022-02-21
 

--- a/react/components/molecules/chat-message/chat-message.js
+++ b/react/components/molecules/chat-message/chat-message.js
@@ -50,14 +50,16 @@ export class ChatMessage extends PureComponent {
         return (
             <View style={[styles.chatMessage, this.props.style]}>
                 <Avatar style={styles.avatar} image={{ uri: this.props.avatarUrl }} size={32} />
-                <View style={styles.content}>
+                <View>
                     <View style={styles.header}>
                         <RNText style={styles.username}>{this.props.username}</RNText>
                         <RNText style={styles.date}>
                             {dateTimeString(this.props.date, { seconds: false })}
                         </RNText>
                     </View>
-                    {this.props.message ? <Text>{this.props.message}</Text> : null}
+                    {this.props.message ? (
+                        <Text style={styles.text}>{this.props.message}</Text>
+                    ) : null}
                     {this.props.attachments.map((attachment, index) => (
                         <View style={this._attachmentsStyle()} key={index}>
                             {isImage(attachment.name) ? (
@@ -91,13 +93,13 @@ const styles = StyleSheet.create({
     avatar: {
         marginEnd: 13
     },
-    content: {
-        flex: 1
-    },
     header: {
         flexDirection: "row",
         marginTop: 3,
         alignItems: "center"
+    },
+    text: {
+        marginEnd: 40
     },
     username: {
         fontFamily: baseStyles.FONT_BOLD,

--- a/react/components/molecules/item/item.js
+++ b/react/components/molecules/item/item.js
@@ -100,7 +100,7 @@ export class Item extends PureComponent {
 const styles = StyleSheet.create({
     item: {
         width: "100%",
-        paddingHorizontal: "4%"
+        paddingHorizontal: 15
     },
     itemFull: {
         paddingHorizontal: 0

--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -156,7 +156,7 @@ const styles = StyleSheet.create({
     keyValuesColumns: {
         flexDirection: "row",
         flexWrap: "wrap",
-        justifyContent: "space-between"
+        justifyContent: "center"
     },
     keyValueWrapperColumns: {
         width: "50%"


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Several problems in tablet:<br>**inconsistent margin horizontal in tablet**<br>![imagem](https://user-images.githubusercontent.com/25725586/155307461-2f9c411e-30fa-43c0-abc7-b8f771e35a11.png)<br>**misaligned expand button in key-values**<br>![imagem](https://user-images.githubusercontent.com/25725586/155307524-cf29a76a-903e-424f-a199-81bbb02882f1.png)<br>**images are centered in chat**<br><img width="972" alt="imagem" src="https://user-images.githubusercontent.com/25725586/155307604-b02a6777-3345-4044-a621-71f3a5e00f54.png"> |
| Dependencies | -- |
| Decisions | - Use the same horizontal margin in `Item` component as the one being used elsewhere - do not use %<br>- Center expand button in `KeyValue`<br>- Align images in chat to the left |
| Animated GIF | <img width="950" alt="imagem" src="https://user-images.githubusercontent.com/25725586/155307842-5eb1ae15-be59-4079-9f33-a124e092cc48.png"><br><img width="946" alt="imagem" src="https://user-images.githubusercontent.com/25725586/155307882-1b9c046f-0a42-423a-8135-ebceedb100ee.png"><br><img width="956" alt="imagem" src="https://user-images.githubusercontent.com/25725586/155307822-6bce3314-e725-4069-95e8-a9df2ec5bb58.png">|
