### PR TITLE
#337: Component that shows placeholder while image is loading - `ImageLoading`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* New component `ImageLoading` that shows a placeholder while the image is loading
+* New component `ImageLoading` that shows a placeholder while the image is loading - [ripe-robin-revamp/#337](https://github.com/ripe-tech/ripe-robin-revamp/issues/337)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* New component `ImageLoading` that shows a placeholder while the image is loading
 
 ### Changed
 

--- a/react/components/atoms/image-loading/image-loading.js
+++ b/react/components/atoms/image-loading/image-loading.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from "react";
-import { Image, Platform, StyleSheet, View, ViewPropTypes } from "react-native";
+import { Image, StyleSheet, View, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 
 import { equal } from "yonius";

--- a/react/components/atoms/image-loading/image-loading.js
+++ b/react/components/atoms/image-loading/image-loading.js
@@ -91,8 +91,8 @@ export class ImageLoading extends PureComponent {
     _imageStyle() {
         return [
             {
-                width: this.state.loading ? 0 : this.props.width,
-                height: this.state.loading ? 0 : this.props.height,
+                width: this.state.loading && this.props.placeholder ? 0 : this.props.width,
+                height: this.state.loading && this.props.placeholder ? 0 : this.props.height,
                 borderRadius: this.props.borderRadius,
                 resizeMode: this.props.resizeMode
             },

--- a/react/components/atoms/image-loading/image-loading.js
+++ b/react/components/atoms/image-loading/image-loading.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from "react";
-import { Image, StyleSheet, View, ViewPropTypes } from "react-native";
+import { Image, Platform, StyleSheet, View, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 
 import { equal } from "yonius";
@@ -42,6 +42,7 @@ export class ImageLoading extends PureComponent {
 
         this.state = {
             loading: false,
+            ended: true,
             cached: false
         };
     }
@@ -76,6 +77,7 @@ export class ImageLoading extends PureComponent {
 
     _onLoadStart() {
         if (this.state.cached) return;
+        if (Platform.OS === "ios" && this.state.ended) return;
         this.setState({
             loading: true
         });

--- a/react/components/atoms/image-loading/image-loading.js
+++ b/react/components/atoms/image-loading/image-loading.js
@@ -1,0 +1,126 @@
+import React, { PureComponent } from "react";
+import { Image, Platform, StyleSheet, View, ViewPropTypes } from "react-native";
+import PropTypes from "prop-types";
+
+import { equal } from "yonius";
+
+export class ImageLoading extends PureComponent {
+    static get propTypes() {
+        return {
+            uri: PropTypes.string,
+            src: PropTypes.string,
+            source: PropTypes.object,
+            width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+            height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+            borderRadius: PropTypes.number,
+            resizeMode: PropTypes.string,
+            placeholder: PropTypes.object,
+            style: ViewPropTypes.style,
+            imageStyle: ViewPropTypes.style,
+            styles: PropTypes.any
+        };
+    }
+
+    static get defaultProps() {
+        return {
+            uri: undefined,
+            src: undefined,
+            source: undefined,
+            width: "100%",
+            height: "100%",
+            borderRadius: undefined,
+            resizeMode: undefined,
+            placeholder: undefined,
+            style: {},
+            imageStyle: {},
+            styles: styles
+        };
+    }
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            loading: false,
+            cached: false
+        };
+    }
+
+    async componentDidMount() {
+        await this._verifyCache();
+    }
+
+    async componentDidUpdate(prevProps) {
+        if (
+            prevProps.uri !== this.props.uri ||
+            prevProps.src !== this.props.uri ||
+            !equal(prevProps.source, this.props.source)
+        ) {
+            await this._verifyCache();
+            this.setState({ ended: false });
+        }
+    }
+
+    async _verifyCache() {
+        const cached = await Image.queryCache([this._imageSource().uri]);
+        this.setState({
+            cached: Object.keys(cached).length > 0
+        });
+    }
+
+    _imageSource() {
+        if (this.props.source) return this.props.source;
+        if (this.props.src) return { uri: this.props.src };
+        return { uri: this.props.uri };
+    }
+
+    _onLoadStart() {
+        if (this.state.cached) return;
+        this.setState({
+            loading: true
+        });
+    }
+
+    _onLoad() {
+        this.setState({
+            loading: false,
+            ended: true
+        });
+    }
+
+    _imageStyle() {
+        return [
+            {
+                width: this.state.loading ? 0 : this.props.width,
+                height: this.state.loading ? 0 : this.props.height,
+                borderRadius: this.props.borderRadius,
+                resizeMode: this.props.resizeMode
+            },
+            this.props.imageStyle
+        ];
+    }
+
+    render() {
+        return (
+            <View style={this.props.style}>
+                {this.state.loading &&
+                    this.props.placeholder &&
+                    React.cloneElement(React.Children.only(this.props.placeholder), {
+                        style: { zIndex: 10 },
+                        height: this.props.height,
+                        width: this.props.width
+                    })}
+                <Image
+                    style={this._imageStyle()}
+                    source={this._imageSource()}
+                    onLoadStart={() => this._onLoadStart()}
+                    onLoad={() => this._onLoad()}
+                />
+            </View>
+        );
+    }
+}
+
+const styles = StyleSheet.create({});
+
+export default ImageLoading;

--- a/react/components/atoms/image-loading/image-loading.js
+++ b/react/components/atoms/image-loading/image-loading.js
@@ -43,7 +43,7 @@ export class ImageLoading extends PureComponent {
         this.state = {
             loading: false,
             ended: true,
-            cached: false
+            cached: true
         };
     }
 

--- a/react/components/atoms/image-loading/image-loading.stories.js
+++ b/react/components/atoms/image-loading/image-loading.stories.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { View } from "react-native";
+import { storiesOf } from "@storybook/react-native";
+import { withKnobs, number, text } from "@storybook/addon-knobs";
+
+import { ImageLoading } from "./image-loading";
+
+storiesOf("Atoms", module)
+    .addDecorator(withKnobs)
+    .add("Image Loading", () => {
+        const uri = text("URI", "https://sandbox.platforme.com/api/compose?model=dummy");
+        const width = number("Width", 200);
+        const height = number("Height", 150);
+
+        return (
+            <ImageLoading
+                uri={uri}
+                width={width}
+                height={height}
+                placeholder={<View style={{ backgroundColor: "#dddddd" }} />}
+            />
+        );
+    });

--- a/react/components/atoms/image-loading/index.js
+++ b/react/components/atoms/image-loading/index.js
@@ -1,0 +1,1 @@
+export * from "./image-loading";

--- a/react/components/atoms/index.js
+++ b/react/components/atoms/index.js
@@ -11,6 +11,7 @@ export * from "./container-draggable";
 export * from "./container-openable";
 export * from "./container-swipeable";
 export * from "./icon";
+export * from "./image-loading";
 export * from "./input";
 export * from "./lightbox";
 export * from "./link";

--- a/react/components/atoms/lightbox/lightbox.js
+++ b/react/components/atoms/lightbox/lightbox.js
@@ -348,6 +348,8 @@ export class Lightbox extends PureComponent {
                         uri={this.props.uri}
                         src={this.props.src}
                         source={this.props.source}
+                        width={this.props.width}
+                        height={this.props.height}
                         resizeMode={this.props.resizeMode}
                         placeholder={this.props.placeholder}
                     />

--- a/react/components/atoms/lightbox/lightbox.js
+++ b/react/components/atoms/lightbox/lightbox.js
@@ -11,6 +11,7 @@ import {
 import { isTabletSize } from "ripe-commons-native";
 
 import { ButtonIcon } from "../button-icon";
+import { ImageLoading } from "../image-loading";
 import { Touchable } from "../touchable";
 
 export class Lightbox extends PureComponent {
@@ -30,6 +31,7 @@ export class Lightbox extends PureComponent {
             resizeModeFullScreen: PropTypes.string,
             closeButton: PropTypes.bool,
             visible: PropTypes.bool,
+            placeholder: PropTypes.object,
             onVisible: PropTypes.func,
             style: ViewPropTypes.style,
             imageStyle: ViewPropTypes.style,
@@ -53,8 +55,10 @@ export class Lightbox extends PureComponent {
             resizeModeFullScreen: "contain",
             closeButton: true,
             visible: false,
+            placeholder: undefined,
             onVisible: () => {},
             style: {},
+            imageStyle: {},
             styles: styles
         };
     }
@@ -315,8 +319,7 @@ export class Lightbox extends PureComponent {
             {
                 width: this.props.width,
                 height: this.props.height,
-                borderRadius: this.props.borderRadius,
-                resizeMode: this.props.resizeMode
+                borderRadius: this.props.borderRadius
             },
             this.props.imageStyle
         ];
@@ -340,7 +343,14 @@ export class Lightbox extends PureComponent {
         return (
             <View style={this.props.style}>
                 <Touchable activeOpacity={0.7} onPress={this.onLightboxPress}>
-                    <Image style={this._imageStyle()} source={this._imageSource()} />
+                    <ImageLoading
+                        style={this._imageStyle()}
+                        uri={this.props.uri}
+                        src={this.props.src}
+                        source={this.props.source}
+                        resizeMode={this.props.resizeMode}
+                        placeholder={this.props.placeholder}
+                    />
                 </Touchable>
                 <Modal
                     animationType="fade"

--- a/react/components/molecules/chat-message/chat-message.js
+++ b/react/components/molecules/chat-message/chat-message.js
@@ -21,6 +21,7 @@ export class ChatMessage extends PureComponent {
                     path: PropTypes.string.isRequired
                 })
             ),
+            imagePlaceholder: PropTypes.object,
             style: ViewPropTypes.style,
             styles: PropTypes.any
         };
@@ -33,6 +34,7 @@ export class ChatMessage extends PureComponent {
             message: undefined,
             date: undefined,
             attachments: [],
+            imagePlaceholder: undefined,
             style: {},
             styles: styles
         };
@@ -68,6 +70,7 @@ export class ChatMessage extends PureComponent {
                                     height={180}
                                     uri={attachment.path}
                                     resizeMode={"contain"}
+                                    placeholder={this.props.imagePlaceholder}
                                 />
                             ) : (
                                 <Link

--- a/react/components/organisms/chat/chat.js
+++ b/react/components/organisms/chat/chat.js
@@ -28,6 +28,7 @@ export class Chat extends PureComponent {
             ),
             aggregationThreshold: PropTypes.number,
             animateScrollBottom: PropTypes.bool,
+            imagePlaceholder: PropTypes.object,
             onNewMessage: PropTypes.func,
             onScrollBottom: PropTypes.func,
             onScroll: PropTypes.func,
@@ -43,6 +44,7 @@ export class Chat extends PureComponent {
             messages: [],
             aggregationThreshold: 120,
             animateScrollBottom: true,
+            imagePlaceholder: undefined,
             onNewMessage: () => {},
             onScrollBottom: () => {},
             onScroll: event => {},
@@ -187,13 +189,14 @@ export class Chat extends PureComponent {
                             {this._aggregatedMessages().map((message, index) => {
                                 return (
                                     <ChatMessage
+                                        key={index}
                                         style={index !== 0 && styles.chatMessage}
                                         avatarUrl={message.avatarUrl}
                                         username={message.username}
                                         message={message.message}
                                         date={message.date}
                                         attachments={message.attachments}
-                                        key={index}
+                                        imagePlaceholder={this.props.imagePlaceholder}
                                     />
                                 );
                             })}


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/337 |
| Dependencies | -- |
| Decisions | - `ImageLoading` component, that shows a placeholder when the images is loading<br>- Does not show placeholder if image is already cached and contains a workaround for iOS to avoid flickering. |
| Animated GIF | ![image-placeholder-loading](https://user-images.githubusercontent.com/25725586/156029005-ec5d21d7-a9a9-4c70-ab3c-6111008722c9.gif)|
