### PR TITLE
#347: Attachment component and its usage in ChatMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Fix image link in `ChatMessage` story
 
 ## [0.20.0] - 2022-03-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* Use new component `Attachment` in `ChatMessage` - [ripe-robin-revamp/#347](https://github.com/ripe-tech/ripe-robin-revamp/issues/347)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* New component `Attachment` that shows a file info and works as a link - [ripe-robin-revamp/#347](https://github.com/ripe-tech/ripe-robin-revamp/issues/347)
 
 ### Changed
 

--- a/react/components/atoms/attachment/attachment.js
+++ b/react/components/atoms/attachment/attachment.js
@@ -1,0 +1,143 @@
+import React, { Component } from "react";
+import { Linking, StyleSheet, Text, View, ViewPropTypes } from "react-native";
+import PropTypes from "prop-types";
+
+import { baseStyles } from "../../../util";
+
+import { Icon } from "../icon";
+import { Touchable } from "../touchable";
+
+export class Attachment extends Component {
+    static get propTypes() {
+        return {
+            filename: PropTypes.string.isRequired,
+            extension: PropTypes.string,
+            url: PropTypes.string,
+            underlayColor: PropTypes.string,
+            activeOpacity: PropTypes.number,
+            onPress: PropTypes.func,
+            style: ViewPropTypes.style,
+            styles: PropTypes.any
+        };
+    }
+
+    static get defaultProps() {
+        return {
+            extension: undefined,
+            url: undefined,
+            underlayColor: "#f3f5ff",
+            activeOpacity: 0.8,
+            onPress: () => {},
+            style: {},
+            styles: styles
+        };
+    }
+
+    constructor(props) {
+        super(props);
+        this.state = {};
+    }
+
+    onPress = event => {
+        if (this.props.url) {
+            Linking.openURL(this.props.url);
+        } else if (this.props.onPress) {
+            this.props.onPress(event);
+        }
+    };
+
+    _extension() {
+        if (this.props.extension) return this.props.extension;
+
+        const extensionIndex = this.props.filename.lastIndexOf(".");
+        if (extensionIndex === -1) return;
+
+        return this.props.filename.substr(extensionIndex + 1);
+    }
+
+    _style() {
+        return [styles.attachment, this.props.style];
+    }
+
+    render() {
+        return (
+            <View style={this._style()}>
+                <Touchable
+                    style={styles.touchable}
+                    underlayColor={this.props.underlayColor}
+                    activeOpacity={this.props.activeOpacity}
+                    onPress={() => this.onPress()}
+                >
+                    <View style={styles.attachmentContainer}>
+                        <View style={styles.image}>
+                            <View style={styles.iconContainer}>
+                                <Icon icon={"file"} color={"#ffffff"} height={25} width={25} />
+                            </View>
+                        </View>
+                        <View style={styles.info}>
+                            <Text style={styles.file} numberOfLines={1}>
+                                {this.props.filename}
+                            </Text>
+                            <Text style={styles.extension}>
+                                {this._extension().toUpperCase()} file
+                            </Text>
+                        </View>
+                    </View>
+                </Touchable>
+            </View>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    attachment: {
+        width: 270,
+        height: 65,
+        borderRadius: 13,
+        borderWidth: 1,
+        borderStyle: "solid",
+        borderColor: "#dfe2e5",
+        overflow: "hidden"
+    },
+    touchable: {
+        flex: 1,
+        padding: 6
+    },
+    attachmentContainer: {
+        flex: 1,
+        flexDirection: "row"
+    },
+    image: {
+        flex: 1
+    },
+    iconContainer: {
+        flex: 1,
+        backgroundColor: "#6051f2",
+        borderRadius: 7,
+        aspectRatio: 1,
+        marginVertical: 5,
+        marginHorizontal: 6,
+        alignItems: "center",
+        justifyContent: "center"
+    },
+    info: {
+        flex: 3,
+        flexDirection: "column",
+        alignSelf: "center",
+        marginRight: 5
+    },
+    file: {
+        fontFamily: baseStyles.FONT_BOLD,
+        color: "#1d2631",
+        fontSize: 16,
+        lineHeight: 18
+    },
+    extension: {
+        fontFamily: baseStyles.FONT,
+        color: "#1d2631",
+        fontSize: 14,
+        lineHeight: 16
+    }
+});
+
+export default Attachment;

--- a/react/components/atoms/attachment/attachments.stories.js
+++ b/react/components/atoms/attachment/attachments.stories.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { storiesOf } from "@storybook/react-native";
+import { withKnobs, number, text } from "@storybook/addon-knobs";
+
+import Attachment from "./attachment";
+
+storiesOf("Atoms", module)
+    .addDecorator(withKnobs)
+    .add("Attachment", () => {
+        const filename = text("Filename", "Order_ready.pdf");
+        const extension = text("Extension", "");
+        const underlayColor = text("Underlay Color", "");
+        const activeOpacity = number("Active Opacity", 0.8);
+
+        return (
+            <Attachment
+                filename={filename || undefined}
+                extension={extension || undefined}
+                underlayColor={underlayColor || undefined}
+                activeOpacity={activeOpacity || undefined}
+            />
+        );
+    });

--- a/react/components/atoms/attachment/index.js
+++ b/react/components/atoms/attachment/index.js
@@ -1,0 +1,1 @@
+export * from "./attachment";

--- a/react/components/atoms/index.js
+++ b/react/components/atoms/index.js
@@ -1,3 +1,4 @@
+export * from "./attachment";
 export * from "./avatar";
 export * from "./badge";
 export * from "./bar-animated";

--- a/react/components/atoms/touchable/touchable.stories.js
+++ b/react/components/atoms/touchable/touchable.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react-native";
-import { withKnobs, boolean, number } from "@storybook/addon-knobs";
+import { withKnobs, boolean, number, text } from "@storybook/addon-knobs";
 import { Alert, StyleSheet, Text } from "react-native";
 
 import { Touchable } from "./touchable";
@@ -9,6 +9,7 @@ storiesOf("Atoms", module)
     .addDecorator(withKnobs)
     .add("Touchable", () => {
         const activeOpacity = number("Active Opacity", 0.5);
+        const underlayColor = text("Underlay Color", "#f3f5ff");
         const disabled = boolean("Disabled", false);
         const onLongPress = () => {
             Alert.alert("onLongPress");
@@ -22,6 +23,7 @@ storiesOf("Atoms", module)
         return (
             <Touchable
                 activeOpacity={activeOpacity}
+                underlayColor={underlayColor}
                 disabled={disabled}
                 onLongPress={onLongPress}
                 onPress={onPress}

--- a/react/components/molecules/chat-message/chat-message.js
+++ b/react/components/molecules/chat-message/chat-message.js
@@ -5,7 +5,7 @@ import { dateTimeString, isImage } from "ripe-commons-native";
 
 import { baseStyles } from "../../../util";
 
-import { Avatar, Lightbox, Link, Text } from "../../atoms";
+import { Attachment, Avatar, Lightbox, Text } from "../../atoms";
 
 export class ChatMessage extends PureComponent {
     static get propTypes() {
@@ -73,10 +73,10 @@ export class ChatMessage extends PureComponent {
                                     placeholder={this.props.imagePlaceholder}
                                 />
                             ) : (
-                                <Link
+                                <Attachment
                                     style={this._attachmentStyle(index)}
-                                    text={attachment.name}
-                                    url={attachment.path}
+                                    filename={attachment.name}
+                                    url={attachment.url}
                                 />
                             )}
                         </View>

--- a/react/components/molecules/chat-message/chat-message.stories.js
+++ b/react/components/molecules/chat-message/chat-message.stories.js
@@ -20,7 +20,7 @@ storiesOf("Molecules", module)
         const attachments = [
             {
                 name: "dummy.pdf",
-                path: "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
+                url: "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
             },
             {
                 name: "image.png",

--- a/react/components/molecules/chat-message/chat-message.stories.js
+++ b/react/components/molecules/chat-message/chat-message.stories.js
@@ -24,9 +24,10 @@ storiesOf("Molecules", module)
             },
             {
                 name: "image.png",
-                path: "https://id.platforme.com/admin/accounts/t-ms%40platforme.com/avatar"
+                path: "https://ripe-core-sbx.platforme.com/api/compose?brand=dummy&model=cube"
             }
         ];
+
         return (
             <ChatMessage
                 avatarUrl={avatarUrl}


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/347 |
| Dependencies | -- |
| Decisions | - New component `Attachment` that shows a file info and works as a link<br>- Use new component `Attachment` in `ChatMessage`<br>- Fix image link in `ChatMessage` story |
| Animated GIF | ![attachment-ios](https://user-images.githubusercontent.com/25725586/158376571-4e3e65a8-1f45-45ef-b8da-6a76453bbd09.gif)![attachment-android](https://user-images.githubusercontent.com/25725586/158376580-81fd9ecb-0058-470b-bea3-3ec4b988f391.gif)|
