### PR TITLE
#347: Tweak avatar positioning in chat message to match new design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* Tweak avatar positioning in `ChatMessage` to match new design - [ripe-robin-revamp/#347](https://github.com/ripe-tech/ripe-robin-revamp/issues/347)
 
 ### Fixed
 

--- a/react/components/atoms/lightbox/lightbox.js
+++ b/react/components/atoms/lightbox/lightbox.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from "react";
-import { Animated, Dimensions, Image, Modal, StyleSheet, View, ViewPropTypes } from "react-native";
+import { Animated, Dimensions, Modal, StyleSheet, View, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 import {
     GestureHandlerRootView,

--- a/react/components/molecules/chat-message/chat-message.js
+++ b/react/components/molecules/chat-message/chat-message.js
@@ -94,7 +94,8 @@ const styles = StyleSheet.create({
         marginEnd: 15
     },
     avatar: {
-        marginEnd: 13
+        marginEnd: 13,
+        marginTop: 3
     },
     header: {
         flexDirection: "row",
@@ -108,14 +109,14 @@ const styles = StyleSheet.create({
         fontFamily: baseStyles.FONT_BOLD,
         marginEnd: 5,
         fontSize: 14,
-        lineHeight: 22,
+        lineHeight: 18,
         color: "#3e566a"
     },
     date: {
         fontFamily: baseStyles.FONT,
         color: "#a4adb5",
         fontSize: 11,
-        lineHeight: 22
+        lineHeight: 18
     }
 });
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/347 |
| Dependencies | |
| Decisions | - Tweak avatar positioning in `ChatMessage` to match new design |
| Animated GIF | Before:<br><img width="1081" alt="image" src="https://user-images.githubusercontent.com/25725586/158384887-ebf16783-9e0d-44f8-86f0-ae5487a3abe9.png"><br>Now:<br>![image](https://user-images.githubusercontent.com/25725586/158384816-0344063f-a9be-4227-92ce-44e346f3b67d.png)|
