### PR TITLE
#347: `AvatarList` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Change chat messages aggregation threshold to 1 hour - [ripe-robin-revamp/#345](https://github.com/ripe-tech/ripe-robin-revamp/issues/345)
 * Use new component `StatusEntry` in `ChatMessage` - [ripe-robin-revamp/#345](https://github.com/ripe-tech/ripe-robin-revamp/issues/345)
 * Adapt `ChatMessage` and `Chat` styling to better adapt to the available size - [ripe-robin-revamp/#345](https://github.com/ripe-tech/ripe-robin-revamp/issues/345)
+* Use new component `AvatarList` in `ChatMessage` and modify `Chat` to use it - [ripe-robin-revamp/#347](https://github.com/ripe-tech/ripe-robin-revamp/issues/347)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * New component `Attachment` that shows a file info and works as a link - [ripe-robin-revamp/#347](https://github.com/ripe-tech/ripe-robin-revamp/issues/347)
 * New component `StatusEntry` that shows the status change entry in a chat - [ripe-robin-revamp/#345](https://github.com/ripe-tech/ripe-robin-revamp/issues/345)
+* New component `AvatarList` that shows avatars in list form - [ripe-robin-revamp/#347](https://github.com/ripe-tech/ripe-robin-revamp/issues/347)
 
 ### Changed
 

--- a/react/components/molecules/avatar-list/avatar-list.js
+++ b/react/components/molecules/avatar-list/avatar-list.js
@@ -1,0 +1,72 @@
+import React, { PureComponent } from "react";
+import { StyleSheet, View, ViewPropTypes } from "react-native";
+import PropTypes from "prop-types";
+import { mix } from "yonius";
+
+import { IdentifiableMixin } from "../../../util";
+
+import { Avatar } from "../../atoms";
+
+export class AvatarList extends mix(PureComponent).with(IdentifiableMixin) {
+    static get propTypes() {
+        return {
+            avatars: PropTypes.arrayOf(PropTypes.string).isRequired,
+            size: PropTypes.number,
+            avatarProps: PropTypes.object,
+            style: ViewPropTypes.style,
+            styles: PropTypes.any
+        };
+    }
+
+    static get defaultProps() {
+        return {
+            label: undefined,
+            size: 40,
+            avatarProps: {},
+            style: {},
+            styles: styles
+        };
+    }
+    _style() {
+        return [styles.avatarList, this.props.style];
+    }
+
+    _avatarStyle(index) {
+        return [
+            styles.avatar,
+            index > 0
+                ? {
+                      marginLeft: -10
+                  }
+                : {}
+        ];
+    }
+
+    _renderAvatars() {
+        return this.props.avatars.map((avatar, index) => (
+            <Avatar
+                style={this._avatarStyle()}
+                image={{ uri: avatar }}
+                size={this.props.size}
+                {...this.props.avatarProps}
+            />
+        ));
+    }
+
+    render() {
+        return <View styles={this._style()}>{this._renderAvatars()}</View>;
+    }
+}
+
+const styles = StyleSheet.create({
+    avatarList: {
+        overflow: "hidden",
+        flexDirection: "column",
+        width: "100%"
+    },
+    avatar: {
+        // flex: 0
+    }
+});
+
+export default AvatarList;

--- a/react/components/molecules/avatar-list/avatar-list.js
+++ b/react/components/molecules/avatar-list/avatar-list.js
@@ -131,8 +131,7 @@ const styles = StyleSheet.create({
     },
     textOverlay: {
         fontFamily: baseStyles.FONT,
-        color: "#ffffff",
-        lineHeight: undefined
+        color: "#ffffff"
     }
 });
 

--- a/react/components/molecules/avatar-list/avatar-list.js
+++ b/react/components/molecules/avatar-list/avatar-list.js
@@ -68,7 +68,11 @@ export class AvatarList extends mix(PureComponent).with(IdentifiableMixin) {
         return [
             styles.textOverlay,
             {
-                fontSize: this.props.size / 2 - 5
+                // the required line height so that the text always
+                // appears vertically centered in the middle of the
+                // avatar image
+                lineHeight: this.props.size / 2 + this.props.size / 8,
+                fontSize: this.props.size / 2
             }
         ];
     }
@@ -78,7 +82,7 @@ export class AvatarList extends mix(PureComponent).with(IdentifiableMixin) {
             <View>
                 <Avatar
                     style={this._avatarStyle(index)}
-                    key={index}
+                    key={`${avatar}-${index}`}
                     image={{ uri: avatar }}
                     size={this.props.size}
                     {...this.props.avatarProps}
@@ -97,7 +101,7 @@ export class AvatarList extends mix(PureComponent).with(IdentifiableMixin) {
 
     render() {
         return (
-            <View styles={styles.avatarList}>
+            <View styles={this._style()}>
                 <View style={styles.avatars}>{this._renderAvatars()}</View>
             </View>
         );
@@ -110,9 +114,7 @@ const styles = StyleSheet.create({
         flexDirection: "row"
     },
     avatars: {
-        flex: 1,
-        flexDirection: "row",
-        backgroundColor: "yellow"
+        flexDirection: "row"
     },
     avatarOverlayContainer: {
         position: "absolute",

--- a/react/components/molecules/avatar-list/avatar-list.js
+++ b/react/components/molecules/avatar-list/avatar-list.js
@@ -30,9 +30,9 @@ export class AvatarList extends mix(PureComponent).with(IdentifiableMixin) {
     }
 
     _avatars() {
-        if (this.props.avatars.length <= this.props.visibleAvatars) return this.props.avatars;
-        const reducedAvatars = this.props.avatars.slice(0, this.props.visibleAvatars + 1);
-        return reducedAvatars;
+        return this.props.avatars.length <= this.props.visibleAvatars
+            ? this.props.avatars
+            : this.props.avatars.slice(0, this.props.visibleAvatars + 1);
     }
 
     _style() {

--- a/react/components/molecules/avatar-list/avatar-list.js
+++ b/react/components/molecules/avatar-list/avatar-list.js
@@ -15,8 +15,7 @@ export class AvatarList extends mix(PureComponent).with(IdentifiableMixin) {
             avatarProps: PropTypes.object,
             visibleAvatars: PropTypes.number,
             style: ViewPropTypes.style,
-            textStyle: ViewPropTypes.style,
-            styles: PropTypes.any
+            textStyle: ViewPropTypes.style
         };
     }
 
@@ -26,8 +25,7 @@ export class AvatarList extends mix(PureComponent).with(IdentifiableMixin) {
             size: 40,
             avatarProps: {},
             visibleAvatars: 3,
-            style: {},
-            styles: styles
+            style: {}
         };
     }
 
@@ -48,7 +46,7 @@ export class AvatarList extends mix(PureComponent).with(IdentifiableMixin) {
                       marginLeft: 0
                   }
                 : {
-                      marginLeft: -1 * (this.props.size / 3)
+                      marginLeft: -1 * (this.props.size / 2)
                   }
         ];
     }
@@ -59,7 +57,7 @@ export class AvatarList extends mix(PureComponent).with(IdentifiableMixin) {
             {
                 width: this.props.size,
                 height: this.props.size,
-                marginLeft: -1 * (this.props.size / 3)
+                marginLeft: -1 * (this.props.size / 2)
             }
         ];
     }

--- a/react/components/molecules/avatar-list/avatar-list.js
+++ b/react/components/molecules/avatar-list/avatar-list.js
@@ -3,9 +3,9 @@ import { StyleSheet, View, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 import { mix } from "yonius";
 
-import { IdentifiableMixin } from "../../../util";
+import { IdentifiableMixin, baseStyles } from "../../../util";
 
-import { Avatar } from "../../atoms";
+import { Avatar, Text } from "../../atoms";
 
 export class AvatarList extends mix(PureComponent).with(IdentifiableMixin) {
     static get propTypes() {
@@ -13,7 +13,9 @@ export class AvatarList extends mix(PureComponent).with(IdentifiableMixin) {
             avatars: PropTypes.arrayOf(PropTypes.string).isRequired,
             size: PropTypes.number,
             avatarProps: PropTypes.object,
+            showNumber: PropTypes.number,
             style: ViewPropTypes.style,
+            textStyle: ViewPropTypes.style,
             styles: PropTypes.any
         };
     }
@@ -23,49 +25,114 @@ export class AvatarList extends mix(PureComponent).with(IdentifiableMixin) {
             label: undefined,
             size: 40,
             avatarProps: {},
+            showNumber: 3,
             style: {},
             styles: styles
         };
     }
+
+    _avatars() {
+        if (this.props.avatars.length <= this.props.showNumber) return this.props.avatars;
+        const reducedAvatars = this.props.avatars.slice(0, this.props.showNumber + 1);
+        return reducedAvatars;
+    }
+
     _style() {
         return [styles.avatarList, this.props.style];
     }
 
     _avatarStyle(index) {
         return [
-            styles.avatar,
-            index > 0
+            index === 0
                 ? {
-                      marginLeft: -10
+                      marginLeft: 0
                   }
-                : {}
+                : {
+                      marginLeft: -1 * (this.props.size / 3)
+                  }
+        ];
+    }
+
+    _avatarOverlayContainerStyle() {
+        return [
+            styles.avatarOverlayContainer,
+            {
+                width: this.props.size,
+                height: this.props.size,
+                marginLeft: -1 * (this.props.size / 3)
+            }
+        ];
+    }
+
+    _avatarOverlayText() {
+        return [
+            styles.textOverlay,
+            {
+                fontSize: this.props.size / 2 - 5
+            }
         ];
     }
 
     _renderAvatars() {
-        return this.props.avatars.map((avatar, index) => (
-            <Avatar
-                style={this._avatarStyle()}
-                image={{ uri: avatar }}
-                size={this.props.size}
-                {...this.props.avatarProps}
-            />
+        return this._avatars().map((avatar, index) => (
+            <View>
+                <Avatar
+                    style={this._avatarStyle(index)}
+                    key={index}
+                    image={{ uri: avatar }}
+                    size={this.props.size}
+                    {...this.props.avatarProps}
+                />
+                {index >= this.props.showNumber && (
+                    <View style={this._avatarOverlayContainerStyle()}>
+                        <View style={styles.avatarOverlay} />
+                        <Text style={this._avatarOverlayText()}>
+                            + {this.props.avatars.length - this.props.showNumber}
+                        </Text>
+                    </View>
+                )}
+            </View>
         ));
     }
 
     render() {
-        return <View styles={this._style()}>{this._renderAvatars()}</View>;
+        return (
+            <View styles={styles.avatarList}>
+                <View style={styles.avatars}>{this._renderAvatars()}</View>
+            </View>
+        );
     }
 }
 
 const styles = StyleSheet.create({
     avatarList: {
         overflow: "hidden",
-        flexDirection: "column",
-        width: "100%"
+        flexDirection: "row"
     },
-    avatar: {
-        // flex: 0
+    avatars: {
+        flex: 1,
+        flexDirection: "row",
+        backgroundColor: "yellow"
+    },
+    avatarOverlayContainer: {
+        position: "absolute",
+        flexDirection: "row",
+        justifyContent: "center",
+        alignItems: "center",
+        borderRadius: 100,
+        overflow: "hidden"
+    },
+    avatarOverlay: {
+        position: "absolute",
+        height: "100%",
+        width: "100%",
+        backgroundColor: "#000000",
+        opacity: 0.4
+    },
+    textOverlay: {
+        fontFamily: baseStyles.FONT,
+        color: "#ffffff",
+        lineHeight: undefined
     }
 });
 

--- a/react/components/molecules/avatar-list/avatar-list.js
+++ b/react/components/molecules/avatar-list/avatar-list.js
@@ -13,7 +13,7 @@ export class AvatarList extends mix(PureComponent).with(IdentifiableMixin) {
             avatars: PropTypes.arrayOf(PropTypes.string).isRequired,
             size: PropTypes.number,
             avatarProps: PropTypes.object,
-            showNumber: PropTypes.number,
+            visibleAvatars: PropTypes.number,
             style: ViewPropTypes.style,
             textStyle: ViewPropTypes.style,
             styles: PropTypes.any
@@ -25,15 +25,15 @@ export class AvatarList extends mix(PureComponent).with(IdentifiableMixin) {
             label: undefined,
             size: 40,
             avatarProps: {},
-            showNumber: 3,
+            visibleAvatars: 3,
             style: {},
             styles: styles
         };
     }
 
     _avatars() {
-        if (this.props.avatars.length <= this.props.showNumber) return this.props.avatars;
-        const reducedAvatars = this.props.avatars.slice(0, this.props.showNumber + 1);
+        if (this.props.avatars.length <= this.props.visibleAvatars) return this.props.avatars;
+        const reducedAvatars = this.props.avatars.slice(0, this.props.visibleAvatars + 1);
         return reducedAvatars;
     }
 
@@ -87,11 +87,11 @@ export class AvatarList extends mix(PureComponent).with(IdentifiableMixin) {
                     size={this.props.size}
                     {...this.props.avatarProps}
                 />
-                {index >= this.props.showNumber && (
+                {index >= this.props.visibleAvatars && (
                     <View style={this._avatarOverlayContainerStyle()}>
                         <View style={styles.avatarOverlay} />
                         <Text style={this._avatarOverlayText()}>
-                            + {this.props.avatars.length - this.props.showNumber}
+                            + {this.props.avatars.length - this.props.visibleAvatars}
                         </Text>
                     </View>
                 )}

--- a/react/components/molecules/avatar-list/avatar-list.stories.js
+++ b/react/components/molecules/avatar-list/avatar-list.stories.js
@@ -9,14 +9,14 @@ storiesOf("Molecules", module)
     .add("Avatar List", () => {
         const avatars = [
             "https://i.pravatar.cc",
-            "https://i.pravatar.cc",
-            "https://i.pravatar.cc",
-            "https://i.pravatar.cc",
-            "https://i.pravatar.cc",
-            "https://i.pravatar.cc",
-            "https://i.pravatar.cc",
-            "https://i.pravatar.cc",
-            "https://i.pravatar.cc"
+            "https://i.pravatar.cc?1",
+            "https://i.pravatar.cc?2",
+            "https://i.pravatar.cc?3",
+            "https://i.pravatar.cc?4",
+            "https://i.pravatar.cc?5",
+            "https://i.pravatar.cc?6",
+            "https://i.pravatar.cc?7",
+            "https://i.pravatar.cc?8"
         ];
         const visibleAvatars = number("Number of visible avatars", 3);
         const size = number("Size", 40);

--- a/react/components/molecules/avatar-list/avatar-list.stories.js
+++ b/react/components/molecules/avatar-list/avatar-list.stories.js
@@ -18,8 +18,8 @@ storiesOf("Molecules", module)
             "https://i.pravatar.cc",
             "https://i.pravatar.cc"
         ];
-        const showNumber = number("Show Number", 3);
+        const visibleAvatars = number("Number of visible avatars", 3);
         const size = number("Size", 40);
 
-        return <AvatarList avatars={avatars} showNumber={showNumber} size={size} />;
+        return <AvatarList avatars={avatars} visibleAvatars={visibleAvatars} size={size} />;
     });

--- a/react/components/molecules/avatar-list/avatar-list.stories.js
+++ b/react/components/molecules/avatar-list/avatar-list.stories.js
@@ -1,0 +1,21 @@
+import React from "react";
+import { storiesOf } from "@storybook/react-native";
+import { withKnobs, number } from "@storybook/addon-knobs";
+
+import { AvatarList } from "./avatar-list";
+
+storiesOf("Molecules", module)
+    .addDecorator(withKnobs)
+    .add("Avatar List", () => {
+        const avatars = [
+            "https://id.platforme.com/admin/accounts/v-fl%40platforme.com/avatar",
+            "https://id.platforme.com/admin/accounts/v-fl%40platforme.com/avatar",
+            "https://id.platforme.com/admin/accounts/v-fl%40platforme.com/avatar",
+            "https://id.platforme.com/admin/accounts/v-fl%40platforme.com/avatar",
+            "https://id.platforme.com/admin/accounts/v-fl%40platforme.com/avatar"
+        ];
+        const showNumber = number("Show Number", 3);
+        const size = number("Size", 40);
+
+        return <AvatarList avatars={avatars} showNumber={showNumber} size={size} />;
+    });

--- a/react/components/molecules/avatar-list/avatar-list.stories.js
+++ b/react/components/molecules/avatar-list/avatar-list.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react-native";
-import { withKnobs, number } from "@storybook/addon-knobs";
+import { withKnobs, number, text } from "@storybook/addon-knobs";
 
 import { AvatarList } from "./avatar-list";
 
@@ -8,11 +8,15 @@ storiesOf("Molecules", module)
     .addDecorator(withKnobs)
     .add("Avatar List", () => {
         const avatars = [
-            "https://id.platforme.com/admin/accounts/v-fl%40platforme.com/avatar",
-            "https://id.platforme.com/admin/accounts/v-fl%40platforme.com/avatar",
-            "https://id.platforme.com/admin/accounts/v-fl%40platforme.com/avatar",
-            "https://id.platforme.com/admin/accounts/v-fl%40platforme.com/avatar",
-            "https://id.platforme.com/admin/accounts/v-fl%40platforme.com/avatar"
+            "https://i.pravatar.cc",
+            "https://i.pravatar.cc",
+            "https://i.pravatar.cc",
+            "https://i.pravatar.cc",
+            "https://i.pravatar.cc",
+            "https://i.pravatar.cc",
+            "https://i.pravatar.cc",
+            "https://i.pravatar.cc",
+            "https://i.pravatar.cc"
         ];
         const showNumber = number("Show Number", 3);
         const size = number("Size", 40);

--- a/react/components/molecules/avatar-list/index.js
+++ b/react/components/molecules/avatar-list/index.js
@@ -1,0 +1,1 @@
+export * from "./avatar-list";

--- a/react/components/molecules/chat-message/chat-message.js
+++ b/react/components/molecules/chat-message/chat-message.js
@@ -6,6 +6,7 @@ import { dateTimeString, isImage } from "ripe-commons-native";
 import { baseStyles } from "../../../util";
 
 import { Attachment, Avatar, Lightbox, StatusEntry, Text } from "../../atoms";
+import { AvatarList } from "../avatar-list";
 
 export class ChatMessage extends PureComponent {
     static get propTypes() {
@@ -17,6 +18,8 @@ export class ChatMessage extends PureComponent {
             message: PropTypes.string,
             status: PropTypes.string,
             statusProps: PropTypes.object,
+            replies: PropTypes.number,
+            repliesAvatars: PropTypes.array,
             attachments: PropTypes.arrayOf(
                 PropTypes.exact({
                     name: PropTypes.string.isRequired,
@@ -37,6 +40,8 @@ export class ChatMessage extends PureComponent {
             message: undefined,
             status: undefined,
             statusProps: {},
+            replies: undefined,
+            repliesAvatars: [],
             attachments: [],
             imagePlaceholder: undefined,
             style: {},
@@ -72,6 +77,14 @@ export class ChatMessage extends PureComponent {
                             status={this.props.status}
                             {...this.props.statusProps}
                         />
+                    ) : null}
+                    {this.props.replies ? (
+                        <View style={styles.replies}>
+                            <AvatarList avatars={this.props.repliesAvatars} size={24} />
+                            <Text style={styles.repliesText}>
+                                {this.props.replies} {this.props.replies > 1 ? "replies" : "reply"}
+                            </Text>
+                        </View>
                     ) : null}
                     {this.props.attachments.map((attachment, index) => (
                         <View style={this._attachmentsStyle()} key={index}>
@@ -115,12 +128,6 @@ const styles = StyleSheet.create({
         flexDirection: "column",
         marginTop: 3
     },
-    text: {
-        marginTop: 4
-    },
-    status: {
-        marginTop: 4
-    },
     username: {
         fontFamily: baseStyles.FONT_BOLD,
         marginEnd: 5,
@@ -133,6 +140,23 @@ const styles = StyleSheet.create({
         color: "#a4adb5",
         fontSize: 11,
         lineHeight: 18
+    },
+    text: {
+        marginTop: 4
+    },
+    status: {
+        marginTop: 4
+    },
+    replies: {
+        marginTop: 8,
+        flexDirection: "row",
+        alignItems: "center"
+    },
+    repliesText: {
+        marginLeft: 8,
+        fontFamily: baseStyles.FONT,
+        fontSize: 14,
+        color: "#6051f2"
     }
 });
 

--- a/react/components/molecules/chat-message/chat-message.stories.js
+++ b/react/components/molecules/chat-message/chat-message.stories.js
@@ -29,6 +29,11 @@ storiesOf("Molecules", module)
             }
         ];
         const status = text("Status", "created");
+        const replies = text("Replies", 10);
+        const repliesAvatars = Array.from(
+            { length: replies },
+            () => "https://id.platforme.com/admin/accounts/ns%40platforme.com/avatar"
+        );
 
         return (
             <View>
@@ -43,6 +48,8 @@ storiesOf("Molecules", module)
                     avatarUrl={avatarUrl}
                     username={username}
                     status={status || undefined}
+                    replies={replies}
+                    repliesAvatars={repliesAvatars}
                     date={date || new Date()}
                 />
             </View>

--- a/react/components/molecules/index.js
+++ b/react/components/molecules/index.js
@@ -1,3 +1,4 @@
+export * from "./avatar-list";
 export * from "./button-toggle";
 export * from "./card";
 export * from "./chat-message";

--- a/react/components/organisms/chat/chat.js
+++ b/react/components/organisms/chat/chat.js
@@ -20,6 +20,8 @@ export class Chat extends PureComponent {
                     message: PropTypes.string,
                     status: PropTypes.string,
                     statusProps: PropTypes.object,
+                    replies: PropTypes.number,
+                    repliesAvatars: PropTypes.array,
                     attachments: PropTypes.arrayOf(
                         PropTypes.exact({
                             name: PropTypes.string.isRequired,
@@ -207,6 +209,8 @@ export class Chat extends PureComponent {
                                         message={message.message}
                                         status={message.status}
                                         statusProps={message.statusProps}
+                                        replies={message.replies}
+                                        repliesAvatars={message.repliesAvatars}
                                         attachments={message.attachments}
                                         imagePlaceholder={this.props.imagePlaceholder}
                                     />

--- a/react/components/organisms/chat/chat.stories.js
+++ b/react/components/organisms/chat/chat.stories.js
@@ -108,6 +108,14 @@ storiesOf("Organisms", module)
                 avatarUrl: "https://id.platforme.com/admin/accounts/ns%40platforme.com/avatar",
                 username: "NFSS10",
                 status: "created",
+                replies: 5,
+                repliesAvatars: [
+                    "https://i.pravatar.cc",
+                    "https://i.pravatar.cc",
+                    "https://i.pravatar.cc",
+                    "https://i.pravatar.cc",
+                    "https://i.pravatar.cc"
+                ],
                 date: 1574950742823,
                 attachments: []
             },

--- a/react/components/organisms/chat/chat.stories.js
+++ b/react/components/organisms/chat/chat.stories.js
@@ -111,10 +111,10 @@ storiesOf("Organisms", module)
                 replies: 5,
                 repliesAvatars: [
                     "https://i.pravatar.cc",
-                    "https://i.pravatar.cc",
-                    "https://i.pravatar.cc",
-                    "https://i.pravatar.cc",
-                    "https://i.pravatar.cc"
+                    "https://i.pravatar.cc?1",
+                    "https://i.pravatar.cc?2",
+                    "https://i.pravatar.cc?3",
+                    "https://i.pravatar.cc?4"
                 ],
                 date: 1574950742823,
                 attachments: []


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/347 |
| Dependencies | -- |
| Decisions | - New component `AvatarList`<br>- Use `AvatarList` in `ChatMessage` and propagate props (`replies` and `repliesAvatatars`) through `Chat`. |
| Animated GIF |![avatar-list](https://user-images.githubusercontent.com/25725586/158801406-93e1ce57-2c1e-42bc-97f8-e9d0b38c8f37.gif)![cht-avatars](https://user-images.githubusercontent.com/25725586/158801409-41d7e60f-6df8-4237-81dd-26e95f673864.gif) |
