### PR TITLE
#316: Tag does not allow text breaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Adapt `ChatMessage` and `Chat` styling to better adapt to the available size - [ripe-robin-revamp/#345](https://github.com/ripe-tech/ripe-robin-revamp/issues/345)
 * Use new component `AvatarList` in `ChatMessage` and modify `Chat` to use it - [ripe-robin-revamp/#347](https://github.com/ripe-tech/ripe-robin-revamp/issues/347)
 * Improve button press animation in item and button tab - [ripe-robin-revamp/#343](https://github.com/ripe-tech/ripe-robin-revamp/issues/343)
+* `Tag` does not allow text breaking and shows ellipsis when there is no enough space - [ripe-robin-revamp/#316](https://github.com/ripe-tech/ripe-robin-revamp/issues/316)
 
 ### Fixed
 

--- a/react/components/atoms/tag/tag.js
+++ b/react/components/atoms/tag/tag.js
@@ -87,7 +87,7 @@ export class Tag extends mix(PureComponent).with(IdentifiableMixin) {
                     />
                 ) : null}
                 {this.props.text ? (
-                    <Text style={this._textStyle()} {...this.id("tag-text")}>
+                    <Text style={this._textStyle()} numberOfLines={1} {...this.id("tag-text")}>
                         {this.props.text}
                     </Text>
                 ) : null}


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/316#issuecomment-1085554127 |
| Dependencies | -- |
| Decisions | - Shows ellipsis in `Tag` instead of breaking text. Went with this approach since going with the one to switch the text was too complicated |
| Animated GIF | <img width="394" alt="imagem" src="https://user-images.githubusercontent.com/25725586/161251143-6e97590e-bd57-4402-af24-6c30a6c08a8e.png">|
