### PR TITLE
version: 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+*
+
+### Changed
+
+*
+
+### Fixed
+
+*
+
+## [0.22.0] - 2022-04-21
+
+### Added
+
 * New `beforeMessages` prop to `Chat` component - [ripe-robin-revamp/#346](https://github.com/ripe-tech/ripe-robin-revamp/issues/346)
 
 ### Changed
@@ -21,10 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Increase font size for iOS in `Select`
 * Make buttons round for touch feedback for Android
 * Support for no overlay and height control from parent in `ContainerOpenable`
-
-### Fixed
-
-*
 
 ## [0.21.0] - 2022-04-08
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-components-react-native",
-    "version": "0.21.0",
+    "version": "0.22.0",
     "description": "RIPE Components for React Native",
     "keywords": [
         "components",


### PR DESCRIPTION
### Added

* New `beforeMessages` prop to `Chat` component - [ripe-robin-revamp/#346](https://github.com/ripe-tech/ripe-robin-revamp/issues/346)

### Changed

* Decrease `ButtonTabText` text size and increase `ButtonTab` icon size
* Remove default border from `StatusEntry`, increase padding and change font
* Add new `Tag` medium size and change default font to bold
* Increase spacing between element in `ChatMessage`
* Increase font size of `View More` text in `KeyValues`
* Increase font size for iOS in `Select`
* Make buttons round for touch feedback for Android
* Support for no overlay and height control from parent in `ContainerOpenable`