### PR TITLE
feat: allow gesture movements on the whole container of `ContainerOpenable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* Allow gesture movements on the whole container of `ContainerOpenable`, controllable by prop
 
 ### Fixed
 

--- a/react/components/atoms/container-draggable/container-draggable.js
+++ b/react/components/atoms/container-draggable/container-draggable.js
@@ -8,6 +8,7 @@ export class ContainerDraggable extends PureComponent {
             childRef: PropTypes.func,
             pressThreshold: PropTypes.number,
             snapCloseThreshold: PropTypes.number,
+            panOnlyOnHeader: PropTypes.bool,
             onVisible: PropTypes.func
         };
     }
@@ -17,6 +18,7 @@ export class ContainerDraggable extends PureComponent {
             childRef: ref => {},
             pressThreshold: 2.5,
             snapCloseThreshold: 0.4,
+            panOnlyOnHeader: true,
             onVisible: visible => {}
         };
     }
@@ -74,7 +76,8 @@ export class ContainerDraggable extends PureComponent {
                 this.props.childRef(ref);
             },
             headerPressable: false,
-            headerProps: this.panResponder.panHandlers
+            headerProps: this.panResponder.panHandlers,
+            contentProps: this.props.panOnlyOnHeader ? {} : this.panResponder.panHandlers
         });
     }
 }

--- a/react/components/atoms/container-openable/container-openable.js
+++ b/react/components/atoms/container-openable/container-openable.js
@@ -26,6 +26,7 @@ export class ContainerOpenable extends PureComponent {
             header: PropTypes.element,
             headerPressable: PropTypes.bool,
             headerProps: PropTypes.object,
+            contentProps: PropTypes.object,
             showKnob: PropTypes.bool,
             overlay: PropTypes.bool,
             overlayPress: PropTypes.bool,
@@ -44,6 +45,7 @@ export class ContainerOpenable extends PureComponent {
             header: undefined,
             headerPressable: true,
             headerProps: {},
+            contentProps: {},
             showKnob: true,
             overlay: true,
             overlayPress: true,
@@ -216,6 +218,7 @@ export class ContainerOpenable extends PureComponent {
                 ) : null}
                 <Animated.View
                     style={this._containerStyle()}
+                    {...this.props.contentProps}
                     onLayout={event => this._onContainerLayout(event)}
                 >
                     {this.props.headerPressable ? (


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Related to the scanning tags feature being developed in Robin (there is no issue) |
| Dependencies | -- |
| Decisions | - Support for applying gesture handling in `ContainerOpenable` with  `ContainerDraggable` to the whole content, instead of just the header - contrable by the prop `panOnlyOnHeader` (default to `true`) |
| Animated GIF | -- |
