### PR TITLE
feat: pan on whole content of ContainerOpenable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Allow gesture movements on the whole container of `ContainerOpenable`, controllable by prop
+* Prop that controls if the `ContainerOpenable` closes on tap
 
 ### Fixed
 

--- a/react/components/atoms/container-draggable/container-draggable.js
+++ b/react/components/atoms/container-draggable/container-draggable.js
@@ -9,6 +9,7 @@ export class ContainerDraggable extends PureComponent {
             pressThreshold: PropTypes.number,
             snapCloseThreshold: PropTypes.number,
             panOnlyOnHeader: PropTypes.bool,
+            closeOnTap: PropTypes.bool,
             onVisible: PropTypes.func
         };
     }
@@ -19,6 +20,7 @@ export class ContainerDraggable extends PureComponent {
             pressThreshold: 2.5,
             snapCloseThreshold: 0.4,
             panOnlyOnHeader: true,
+            closeOnTap: true,
             onVisible: visible => {}
         };
     }
@@ -55,10 +57,13 @@ export class ContainerDraggable extends PureComponent {
     };
 
     onPanResponderRelease = (event, gestureState) => {
-        if (!this.dragging) {
+        if (!this.dragging && this.props.closeOnTap) {
             this.child.onHeaderPress();
             return;
         }
+
+        // if no drag was made return immediatly
+        if (!this.contentHeightPercentage) return;
 
         this.dragging = false;
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | - Support for applying gesture handling in `ContainerOpenable` with  `ContainerDraggable` to the whole content, instead of just the header - contrable by the prop `panOnlyOnHeader` (default to `true`) <br>- Prop that controls if the `ContainerOpenable` closes on tap |
| Animated GIF | -- |
