### PR TITLE
fix: increase top padding in `ChatMessage` content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Increase top padding in `ChatMessage` content
 
 ## [0.23.0] - 2022-04-29
 

--- a/react/components/molecules/chat-message/chat-message.js
+++ b/react/components/molecules/chat-message/chat-message.js
@@ -181,7 +181,9 @@ const styles = StyleSheet.create({
         flexDirection: "column",
         marginTop: 3
     },
-    content: {},
+    content: {
+        paddingTop: 10
+    },
     username: {
         fontFamily: baseStyles.FONT_BOLD,
         marginEnd: 5,
@@ -194,9 +196,6 @@ const styles = StyleSheet.create({
         color: "#a4adb5",
         fontSize: 11,
         lineHeight: 18
-    },
-    text: {
-        marginTop: 4
     },
     status: {
         marginTop: 5,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Issue mentioned by @joamag  |
| Dependencies | -- |
| Decisions | - Increase top padding in `ChatMessage` content to match the one in the chat |
| Animated GIF | Before:<br>![image](https://user-images.githubusercontent.com/25725586/166217628-109278a4-1a01-4b1f-b953-cfc4d9bb273f.png)<br>Now:<br><img width="392" alt="image" src="https://user-images.githubusercontent.com/25725586/166217599-b8a9d02b-7965-4103-8232-7cc82b08c323.png">|
