### PR TITLE
fix: misalignment in replies text in `ChatMessage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Increase top padding in `ChatMessage` content
+* Fix misalignment in replies text in `ChatMessage`
 
 ## [0.23.0] - 2022-04-29
 

--- a/react/components/molecules/chat-message/chat-message.js
+++ b/react/components/molecules/chat-message/chat-message.js
@@ -198,7 +198,6 @@ const styles = StyleSheet.create({
         lineHeight: 18
     },
     status: {
-        marginTop: 5,
         marginBottom: 3
     },
     replies: {
@@ -210,6 +209,8 @@ const styles = StyleSheet.create({
         marginLeft: 8,
         fontFamily: baseStyles.FONT,
         fontSize: 14,
+        lineHeight: 14,
+        marginTop: 3,
         color: "#6051f2"
     }
 });


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Replies text was misaligned |
| Dependencies | -- |
| Decisions | -- |
| Animated GIF | <img width="389" alt="image" src="https://user-images.githubusercontent.com/25725586/166270021-48c35371-fc6d-4d1e-8fc3-64fbb17430f0.png">|
