### PR TITLE
fix: placeholder text animation in listing search expand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Increase top padding in `ChatMessage` content
 * Fix misalignment in replies text in `ChatMessage`
+* Fix the placeholder text appearance in search input expand animation - [ripe-robin-revamp/#329](https://github.com/ripe-tech/ripe-robin-revamp/issues/329)
 
 ## [0.23.0] - 2022-04-29
 

--- a/react/components/organisms/listing/listing.js
+++ b/react/components/organisms/listing/listing.js
@@ -234,9 +234,6 @@ export class Listing extends Component {
     }
 
     _shrinkSearchBar() {
-        // set select text as visible
-        this.setState({ placeholderColorAlpha: 1 });
-
         // animate search bar width to normal
         // and increase dropdown select width
         Animated.timing(this.state.searchWidth, {
@@ -245,7 +242,10 @@ export class Listing extends Component {
             useNativeDriver: false,
             easing: Easing.inOut(Easing.ease)
         }).start(() => {
-            this.setState({ expanded: false });
+            this.setState({
+                expanded: false,
+                placeholderColorAlpha: 1
+            });
         });
     }
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/329 |
| Dependencies | -- |
| Decisions | Placeholder opacity only changed after animation ends (it can't be done gradually/interpolated, so its either at the start or at the end of the animation). |
| Animated GIF | ![fix-placeholder-text-opacity](https://user-images.githubusercontent.com/16060539/166648649-7ddffb1c-2ee8-4d1b-908e-9009bf0b8040.gif) |
