### PR TITLE
feat: improve iOS chat scroll responsiveness

### DIFF
--- a/react/components/organisms/chat/chat.js
+++ b/react/components/organisms/chat/chat.js
@@ -225,7 +225,7 @@ export class Chat extends PureComponent {
                     style={this._chatMessagesContainerStyle()}
                     ref={ref => (this.scrollViewComponent = ref)}
                     onScroll={this.onScroll}
-                    scrollEventThrottle={4}
+                    scrollEventThrottle={13}
                 >
                     {this.props.messages.length === 0 ? (
                         this._renderNoMessages()


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/pull/370 |
| Decisions | - Improve animation reaction by increasing [responsiveness threshold of the scrollview](https://reactnative.dev/docs/scrollview#scrolleventthrottle-ios) (only affects iOS) <br> - No changelog entry considering the small improvement. |
