### PR TITLE
#360 - Listing: add prop to override listing content when refreshing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Add `textStyle` prop to `ToastMessage`
 * Add border to `Search` component
+* Add `renderContentRefreshing` prop to `Listing` allowing content override when refreshing - [ripe-robin-revamp/#360](https://github.com/ripe-tech/ripe-robin-revamp/issues/360)
 
 ### Changed
 

--- a/react/components/organisms/listing/listing.js
+++ b/react/components/organisms/listing/listing.js
@@ -20,6 +20,7 @@ export class Listing extends Component {
             getItems: PropTypes.func,
             itemsRequestLimit: PropTypes.number,
             renderItem: PropTypes.func.isRequired,
+            renderContentRefreshing: PropTypes.func,
             filters: PropTypes.array,
             filtersValue: PropTypes.object,
             itemsSortField: PropTypes.string,
@@ -427,6 +428,45 @@ export class Listing extends Component {
         );
     };
 
+    _renderListing = () => {
+        return (
+            <FlatList
+                ref={el => (this.flatListRef = el)}
+                key={"items"}
+                style={styles.flatList}
+                data={this.state.items}
+                refreshing={this.props.refreshing && this.state.refreshing}
+                onRefresh={this.onRefresh}
+                onEndReached={this.onEndReached}
+                onEndReachedThreshold={this.props.onEndReachedThreshold}
+                renderItem={({ item, index }) => this.props.renderItem(item, index)}
+                keyExtractor={item => String(item.id)}
+                ListEmptyComponent={this._renderEmptyList()}
+                ListFooterComponent={<View style={styles.flatListBottom} />}
+                {...this.props.flatListProps}
+            />
+        );
+    };
+
+    _renderHeader = () => {
+        return (
+            <View
+                style={this._searchingHeaderStyle()}
+                onLayout={event => this._onSearchHeaderViewLayout(event)}
+            >
+                {this._renderSearch()}
+                {this._renderFilters()}
+            </View>
+        );
+    };
+
+    _renderContent = () => {
+        if (this.state.refreshing && this.props.renderContentRefreshing) {
+            return this.props.renderContentRefreshing();
+        }
+        return this._renderListing();
+    };
+
     _renderLoading = () => {
         if (!this.state.loading && !this.props.loading) return null;
         return <ActivityIndicator style={styles.loadingIndicator} size="large" color="#6687f6" />;
@@ -435,28 +475,8 @@ export class Listing extends Component {
     render() {
         return (
             <View style={this._style()}>
-                <View
-                    style={this._searchingHeaderStyle()}
-                    onLayout={event => this._onSearchHeaderViewLayout(event)}
-                >
-                    {this._renderSearch()}
-                    {this._renderFilters()}
-                </View>
-                <FlatList
-                    ref={el => (this.flatListRef = el)}
-                    key={"items"}
-                    style={styles.flatList}
-                    data={this.state.items}
-                    refreshing={this.props.refreshing && this.state.refreshing}
-                    onRefresh={this.onRefresh}
-                    onEndReached={this.onEndReached}
-                    onEndReachedThreshold={this.props.onEndReachedThreshold}
-                    renderItem={({ item, index }) => this.props.renderItem(item, index)}
-                    keyExtractor={item => String(item.id)}
-                    ListEmptyComponent={this._renderEmptyList()}
-                    ListFooterComponent={<View style={styles.flatListBottom} />}
-                    {...this.props.flatListProps}
-                />
+                {this._renderHeader()}
+                {this._renderContent()}
                 {this._renderLoading()}
             </View>
         );


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/360 |
| Decisions | - Add `renderContentRefreshing` prop to `Listing` allowing content override when refreshing |

