### PR TITLE
fix: cropped `no-message` chat icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix the placeholder text appearance in search input expand animation - [ripe-robin-revamp/#329](https://github.com/ripe-tech/ripe-robin-revamp/issues/329)
 * Fix problem with `@react-native-community/eslint-config@3.0.2` that causes the `lint` command to fail
 * Switch deprecated svgo config
+* Cropped `no-message` chat icon
 
 ## [0.23.0] - 2022-04-29
 

--- a/react/components/organisms/chat/chat.js
+++ b/react/components/organisms/chat/chat.js
@@ -212,6 +212,7 @@ export class Chat extends PureComponent {
                 <Image
                     style={styles.noMessagesImage}
                     source={require("./assets/no-messages.png")}
+                    resizeMode={"contain"}
                 />
                 <Text style={styles.noMessagesText}>No messages, yet</Text>
             </View>


### PR DESCRIPTION
| - | - |
| --- | --- |
| Animated GIF | before: <br> <img width="372" alt="Screenshot 2022-06-02 at 16 32 52" src="https://user-images.githubusercontent.com/8842023/171672408-75d2e05f-ba8c-43a3-b67b-d14f955f6058.png"> <br> after: <br><img width="377" alt="Screenshot 2022-06-02 at 16 32 26" src="https://user-images.githubusercontent.com/8842023/171673304-3360b8bb-a69c-4b2b-a92e-cca6670678e8.png"> |
