### PR TITLE
version: 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+*
+
+### Changed
+
+*
+
+### Fixed
+
+*
+
+## [0.24.0] - 2022-06-20
+
+### Added
+
 * Add `textStyle` prop to `ToastMessage`
 * Add border to `Search` component
 * Add `renderContentRefreshing` prop to `Listing` allowing content override when refreshing - [ripe-robin-revamp/#360](https://github.com/ripe-tech/ripe-robin-revamp/issues/360)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-components-react-native",
-    "version": "0.23.0",
+    "version": "0.24.0",
     "description": "RIPE Components for React Native",
     "keywords": [
         "components",


### PR DESCRIPTION
### Added

* Add `textStyle` prop to `ToastMessage`
* Add border to `Search` component
* Add `renderContentRefreshing` prop to `Listing` allowing content override when refreshing - [ripe-robin-revamp/#360](https://github.com/ripe-tech/ripe-robin-revamp/issues/360)
* Add more styling props for `tabs`, `key-values` and `profile` components - [ripe-robin-revamp/#372](https://github.com/ripe-tech/ripe-robin-revamp/issues/372)

### Changed

* Add node versions `17` and `18` to the Github workflow

### Fixed

* Increase top padding in `ChatMessage` content
* Fix misalignment in replies text in `ChatMessage`
* Fix the placeholder text appearance in search input expand animation - [ripe-robin-revamp/#329](https://github.com/ripe-tech/ripe-robin-revamp/issues/329)
* Fix problem with `@react-native-community/eslint-config@3.0.2` that causes the `lint` command to fail
* Switch deprecated svgo config
