### PR TITLE
feat: using different border color when search input is focused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Allow to use a different border color when search input is focused
 
 ### Changed
 

--- a/react/components/molecules/search/search.js
+++ b/react/components/molecules/search/search.js
@@ -92,12 +92,22 @@ export class Search extends PureComponent {
         return [styles.search, this.props.style];
     };
 
+    _inputStyle = () => {
+        return [
+            styles.input,
+            this.state.focused ? styles.inputFocused : {},
+            this.state.focused && StyleSheet.flatten(this.props.style)?.inputFocused
+                ? StyleSheet.flatten(this.props.style).inputFocused
+                : {}
+        ];
+    };
+
     render() {
         return (
             <Animated.View style={this._style()}>
                 <Input
                     ref={el => (this.textInputComponent = el)}
-                    style={styles.input}
+                    style={this._inputStyle()}
                     value={this.state.valueData}
                     placeholder={this.props.placeholder}
                     placeholderTextColor={"#223645"}
@@ -141,6 +151,9 @@ const styles = StyleSheet.create({
         borderColor: "#e4e8f0",
         minHeight: 40,
         backgroundColor: "#ffffff"
+    },
+    inputFocused: {
+        borderColor: "#4A6FE9"
     },
     button: {
         position: "absolute",


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Search input border color is not changing when it is focused as it is expected by the [design](https://www.figma.com/file/KVbltf1J5ezwoILkQSdqCw/RIPE-Robin---Public?node-id=1219%3A3569) |
| Decisions | - Changing search input border color and allowing for override style color to be passed from prop style. |
