### PR TITLE
fix: include svga files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Including `*.svga` files in `package.json`
 
 ## [0.27.3] - 2022-09-14
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "res/**/*.ico",
         "res/**/*.png",
         "res/**/*.svg",
+        "res/**/*.svga",
         "test/**/*.js",
         "react/**/*.js",
         "react/**/*.ico",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
         "react/**/*.js",
         "react/**/*.ico",
         "react/**/*.png",
-        "react/**/*.svg"
+        "react/**/*.svg",
+        "react/**/*.svga"
     ],
     "scripts": {
         "cleanup": "rm -rf node_modules && rm -f package-lock.json",


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | - Build in Robin is not detecting `no-messages-animation.svga` file |
| Decisions | - Include svga files in `package.json` files list |
