### PR TITLE
Add and use ios input style to override select color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Add and adapt to use new prop `inputIOSStyle` to override `select` color in `listing`
 
 ### Changed
 

--- a/react/components/molecules/select/select.js
+++ b/react/components/molecules/select/select.js
@@ -25,6 +25,7 @@ export class Select extends mix(PureComponent).with(IdentifiableMixin) {
             placeholderStyle: PropTypes.object,
             iconContainerStyle: PropTypes.object,
             inputAndroidStyle: PropTypes.object,
+            inputIOSStyle: PropTypes.object,
             inputIOSContainerStyle: PropTypes.object,
             styles: PropTypes.any
         };
@@ -47,6 +48,7 @@ export class Select extends mix(PureComponent).with(IdentifiableMixin) {
             placeholderStyle: {},
             iconContainerStyle: {},
             inputAndroidStyle: {},
+            inputIOSStyle: {},
             inputIOSContainerStyle: {},
             styles: styles
         };
@@ -142,6 +144,13 @@ export class Select extends mix(PureComponent).with(IdentifiableMixin) {
                 height: 40,
                 ...this.props.inputAndroidStyle
             },
+            inputIOS: {
+                color: "red",
+                fontFamily: baseStyles.FONT_BOOK,
+                fontSize: 15,
+                lineHeight: 18,
+                ...this.props.inputIOSStyle
+            },
             inputIOSContainer: {
                 backgroundColor: this._inputBackgroundColor(),
                 borderColor: this._inputBorderColor(),
@@ -152,12 +161,6 @@ export class Select extends mix(PureComponent).with(IdentifiableMixin) {
                 height: 40,
                 justifyContent: "center",
                 ...this.props.inputIOSContainerStyle
-            },
-            inputIOS: {
-                color: "#24425a",
-                fontFamily: baseStyles.FONT_BOOK,
-                fontSize: 15,
-                lineHeight: 18
             },
             placeholder: {
                 color: "#24425a",

--- a/react/components/organisms/listing/listing.js
+++ b/react/components/organisms/listing/listing.js
@@ -410,6 +410,7 @@ export class Listing extends Component {
                     placeholderStyle={this._selectPlaceholderStyle()}
                     iconContainerStyle={styles.selectIconContainer}
                     inputAndroidStyle={this._selectPickerAndroidStyle()}
+                    inputIOSStyle={this._selectPickerIOSStyle()}
                     inputIOSContainerStyle={this._selectPickerIOSStyle()}
                     placeholder={item.placeholder}
                     options={item.options}

--- a/react/components/organisms/listing/listing.js
+++ b/react/components/organisms/listing/listing.js
@@ -85,7 +85,7 @@ export class Listing extends Component {
 
         this.state = {
             searchWidth: new Animated.Value(0),
-            placeholderColorAlpha: 1,
+            placeholderColorAlpha: "FF",
             expanded: false,
             searchText: "",
             itemsOffset: 0,
@@ -224,7 +224,7 @@ export class Listing extends Component {
 
     _expandSearchBar() {
         // set select text as transparent
-        this.setState({ placeholderColorAlpha: 0 });
+        this.setState({ placeholderColorAlpha: "00" });
 
         // animate search bar width to maximum
         // and decrease dropdown select width
@@ -249,7 +249,7 @@ export class Listing extends Component {
         }).start(() => {
             this.setState({
                 expanded: false,
-                placeholderColorAlpha: 1
+                placeholderColorAlpha: "FF"
             });
         });
     }
@@ -324,7 +324,7 @@ export class Listing extends Component {
      * This way we change only the text color and by reducing the alpha
      * channel we get the same effect as reducing the opacity.
      */
-    _selectTextColor = () => `rgba(36,66,90,${this.state.placeholderColorAlpha})`;
+    _selectTextColor = () => `#24425a${this.state.placeholderColorAlpha}`;
 
     /**
      * Notice this does not follow the ReactNative style standard


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | - Added missing `inputIOSStyle` and use it in listing to override and make text transparent when search is focused. |
