### PR TITLE
fix: add guard to flatlist reference

### DIFF
--- a/react/components/organisms/listing/listing.js
+++ b/react/components/organisms/listing/listing.js
@@ -120,6 +120,7 @@ export class Listing extends Component {
     }
 
     scrollToTop = () => {
+        if (!this.flatListRef) return;
         this.flatListRef.scrollToOffset({ animated: true, offset: 0 });
     };
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | - Add guard to `flatListRef` as it in some moments is `undefined` and if we spam it fails |
