### PR TITLE
feat: Add sections to `key-values` components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* Add sections to `key-values` components - [ripe-robin-revamp/#330](https://github.com/ripe-tech/ripe-robin-revamp/issues/330)
 
 ### Fixed
 

--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -159,31 +159,6 @@ export class KeyValues extends PureComponent {
                         {item.section && (
                             <View>
                                 <Text style={styles.sectionTitle}>{item.key}</Text>
-                                {item.section.map((item, index) => (
-                                    <KeyValue
-                                        style={this._keyValueStyle(index)}
-                                        key={item.key}
-                                        _key={item.key}
-                                        value={item.value}
-                                        keyColor={item.keyColor}
-                                        valueColor={item.valueColor}
-                                        border={item.border}
-                                        icon={item.icon}
-                                        iconBackgroundColor={item.iconBackgroundColor}
-                                        iconColor={item.iconColor}
-                                        iconSize={item.iconSize}
-                                        iconHeight={item.iconHeight}
-                                        iconWidth={item.iconWidth}
-                                        iconStrokeWidth={item.iconStrokeWidth}
-                                        pressable={item.pressable}
-                                        clipboard={item.clipboard}
-                                        onPress={item.onPress}
-                                        onButtonIconPress={item.onButtonIconPress}
-                                        onLongPress={item.onLongPress}
-                                    >
-                                        {item.valueComponent}
-                                    </KeyValue>
-                                ))}
                             </View>
                         )}
                     </View>

--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -126,6 +126,10 @@ export class KeyValues extends PureComponent {
         return this.props.keyValueTwoColumns && index % 2 > 0 ? styles.keyValueColumnRight : {};
     };
 
+    _sectionTitle = style => {
+        return [styles.sectionTitle, style];
+    };
+
     render() {
         return (
             <View style={this._style()}>
@@ -156,7 +160,7 @@ export class KeyValues extends PureComponent {
                                 {item.valueComponent}
                             </KeyValue>
                         )}
-                        {item.section && <Text style={styles.sectionTitle}>{item.key}</Text>}
+                        {item.section && <Text style={this._sectionTitle(item?.style)}>{item.key}</Text>}
                     </View>
                 ))}
                 {this._showButton() && this._renderExpandButton()}

--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -156,11 +156,7 @@ export class KeyValues extends PureComponent {
                                 {item.valueComponent}
                             </KeyValue>
                         )}
-                        {item.section && (
-                            <View>
-                                <Text style={styles.sectionTitle}>{item.key}</Text>
-                            </View>
-                        )}
+                        {item.section && <Text style={styles.sectionTitle}>{item.key}</Text>}
                     </View>
                 ))}
                 {this._showButton() && this._renderExpandButton()}

--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -78,7 +78,7 @@ export class KeyValues extends PureComponent {
     };
 
     _shouldShow = item => {
-        return Boolean(item.value) || this.props.showUnset;
+        return Boolean(item.value || this.props.showUnset) && !item.section;
     };
 
     _showButton = item => {
@@ -156,6 +156,36 @@ export class KeyValues extends PureComponent {
                                 {item.valueComponent}
                             </KeyValue>
                         )}
+                        {item.section && (
+                            <View>
+                                <Text style={styles.sectionTitle}>{item.key}</Text>
+                                {item.section.map((item, index) => (
+                                    <KeyValue
+                                        style={this._keyValueStyle(index)}
+                                        key={item.key}
+                                        _key={item.key}
+                                        value={item.value}
+                                        keyColor={item.keyColor}
+                                        valueColor={item.valueColor}
+                                        border={item.border}
+                                        icon={item.icon}
+                                        iconBackgroundColor={item.iconBackgroundColor}
+                                        iconColor={item.iconColor}
+                                        iconSize={item.iconSize}
+                                        iconHeight={item.iconHeight}
+                                        iconWidth={item.iconWidth}
+                                        iconStrokeWidth={item.iconStrokeWidth}
+                                        pressable={item.pressable}
+                                        clipboard={item.clipboard}
+                                        onPress={item.onPress}
+                                        onButtonIconPress={item.onButtonIconPress}
+                                        onLongPress={item.onLongPress}
+                                    >
+                                        {item.valueComponent}
+                                    </KeyValue>
+                                ))}
+                            </View>
+                        )}
                     </View>
                 ))}
                 {this._showButton() && this._renderExpandButton()}
@@ -185,6 +215,19 @@ const styles = StyleSheet.create({
         color: "#4f7af8",
         fontSize: 16,
         fontFamily: baseStyles.FONT_REGULAR
+    },
+    sectionTitle: {
+        height: 75,
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        lineHeight: 75,
+        paddingLeft: 16,
+        backgroundColor: "#f5f7f9",
+        color: "#223645",
+        fontSize: 14,
+        fontWeight: "700",
+        textTransform: "capitalize"
     }
 });
 

--- a/react/components/molecules/key-values/key-values.js
+++ b/react/components/molecules/key-values/key-values.js
@@ -160,7 +160,9 @@ export class KeyValues extends PureComponent {
                                 {item.valueComponent}
                             </KeyValue>
                         )}
-                        {item.section && <Text style={this._sectionTitle(item?.style)}>{item.key}</Text>}
+                        {item.section && (
+                            <Text style={this._sectionTitle(item?.style)}>{item.key}</Text>
+                        )}
                     </View>
                 ))}
                 {this._showButton() && this._renderExpandButton()}

--- a/react/components/molecules/key-values/key-values.stories.js
+++ b/react/components/molecules/key-values/key-values.stories.js
@@ -11,7 +11,7 @@ storiesOf("Molecules", module)
             { key: "E-mail", value: "gcc@platforme.com" },
             { key: "Company", value: "Platforme", border: "none" },
             { key: "Position", value: "Head of Software Development", border: "soft" },
-            { separator: "Nationality" },
+            { section: "Nationality" },
             { key: "Birth date", value: "14/03/1993", border: "hard" },
             { key: "Nationality", value: "Portuguese" }
         ];

--- a/react/components/molecules/key-values/key-values.stories.js
+++ b/react/components/molecules/key-values/key-values.stories.js
@@ -12,7 +12,21 @@ storiesOf("Molecules", module)
             { key: "Company", value: "Platforme", border: "none" },
             { key: "Position", value: "Head of Software Development", border: "soft" },
             { key: "Birth date", value: "14/03/1993", border: "hard" },
-            { key: "Nationality", value: "Portuguese" }
+            { key: "Nationality", value: "Portuguese" },
+            {
+                key: "section",
+                section: [
+                    { key: "section-E-mail", value: "gcc@platforme.com" },
+                    { key: "section-Company", value: "Platforme", border: "none" },
+                    {
+                        key: "section-Position",
+                        value: "Head of Software Development",
+                        border: "soft"
+                    },
+                    { key: "section-Birth date", value: "14/03/1993", border: "hard" },
+                    { key: "section-Nationality", value: "Portuguese" }
+                ]
+            }
         ];
         const twoColumns = boolean("Two Columns", false);
         const expanded = boolean("Expanded", false);

--- a/react/components/molecules/key-values/key-values.stories.js
+++ b/react/components/molecules/key-values/key-values.stories.js
@@ -11,22 +11,9 @@ storiesOf("Molecules", module)
             { key: "E-mail", value: "gcc@platforme.com" },
             { key: "Company", value: "Platforme", border: "none" },
             { key: "Position", value: "Head of Software Development", border: "soft" },
+            { separator: "Nationality" },
             { key: "Birth date", value: "14/03/1993", border: "hard" },
-            { key: "Nationality", value: "Portuguese" },
-            {
-                key: "section",
-                section: [
-                    { key: "section-E-mail", value: "gcc@platforme.com" },
-                    { key: "section-Company", value: "Platforme", border: "none" },
-                    {
-                        key: "section-Position",
-                        value: "Head of Software Development",
-                        border: "soft"
-                    },
-                    { key: "section-Birth date", value: "14/03/1993", border: "hard" },
-                    { key: "section-Nationality", value: "Portuguese" }
-                ]
-            }
+            { key: "Nationality", value: "Portuguese" }
         ];
         const twoColumns = boolean("Two Columns", false);
         const expanded = boolean("Expanded", false);


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/330 |
| Decisions | - Add a section property with a `key` that will be the name of the sections and with its own key values |
| Animated GIF | ![gLM7WLkhth](https://user-images.githubusercontent.com/8842023/191701739-26141f2a-f7ab-40c4-b6e0-cf98bd8b7054.gif) |
