### PR TITLE
#472 Fix tab visibility undesired extra padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Fix tab visibility undesired extra padding - [ripe-robin-revamp/#472](https://github.com/ripe-tech/ripe-robin-revamp/issues/472])
 
 ## [0.27.7] - 2022-10-21
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "react-native-image-picker": "^4.10.0",
         "react-native-linear-gradient": "^2.6.2",
         "react-native-picker-select": "^8.0.4",
-        "react-native-safe-area-context": "^3.3.2",
+        "react-native-safe-area-context": "^4.4.1",
         "react-native-safe-area-view": "^1.1.1",
         "react-native-svg": "^12.3.0",
         "react-native-webview": "^11.23.1",

--- a/react/components/molecules/tabs/tabs.js
+++ b/react/components/molecules/tabs/tabs.js
@@ -141,13 +141,6 @@ export class Tabs extends PureComponent {
     render() {
         return (
             <SafeAreaView style={this._style()}>
-                {this._animatedBarEnabled() ? (
-                    <BarAnimated
-                        style={this._barAnimatedStyle()}
-                        offset={this.state.animatedBarOffset}
-                        width={this.state.animatedBarWidth}
-                    />
-                ) : null}
                 {!this._isHidden() &&
                     this.props.tabs.map((tab, index) =>
                         !tab.hidden ? (

--- a/react/components/molecules/tabs/tabs.js
+++ b/react/components/molecules/tabs/tabs.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from "react";
 import { Keyboard, StyleSheet, View } from "react-native";
-import SafeAreaView from "react-native-safe-area-view";
+import { SafeAreaView } from "react-native-safe-area-context";
 import PropTypes from "prop-types";
 
 import { BarAnimated, ButtonTab } from "../../atoms";
@@ -131,7 +131,7 @@ export class Tabs extends PureComponent {
     };
 
     _style = () => {
-        return [styles.tabs, this.props.style];
+        return [styles.tabs, this.props.style, this._isHidden() ? { display: "none" } : {}];
     };
 
     _barAnimatedStyle = () => {
@@ -140,7 +140,7 @@ export class Tabs extends PureComponent {
 
     render() {
         return (
-            <SafeAreaView style={this._style()}>
+            <SafeAreaView edges={["bottom"]} style={this._style()}>
                 {this._animatedBarEnabled() ? (
                     <BarAnimated
                         style={this._barAnimatedStyle()}
@@ -148,39 +148,38 @@ export class Tabs extends PureComponent {
                         width={this.state.animatedBarWidth}
                     />
                 ) : null}
-                {!this._isHidden() &&
-                    this.props.tabs.map((tab, index) =>
-                        !tab.hidden ? (
-                            <View
-                                style={styles.buttonTab}
-                                key={tab.id}
-                                onLayout={event => this._onTabLayout(event, index)}
-                            >
-                                <ButtonTab
-                                    text={tab.text}
-                                    color={tab.color}
-                                    colorSelected={tab.colorSelected}
-                                    disabled={tab.disabled}
-                                    fill={tab.fill}
-                                    fillSelected={tab.fillSelected}
-                                    badgeAnimationDuration={tab.badgeAnimationDuration}
-                                    badgeBackgroundColor={tab.badgeBackgroundColor}
-                                    badgeColor={tab.badgeColor}
-                                    badgeCount={tab.badgeCount}
-                                    badgeCountThreshold={tab.badgeCountThreshold}
-                                    badgeHasAnimation={tab.badgeHasAnimation}
-                                    badgeText={tab.badgeText}
-                                    icon={tab.icon}
-                                    iconSelected={tab.iconSelected}
-                                    iconStrokeWidth={tab.iconStrokeWidth}
-                                    iconSelectedStrokeWidth={tab.iconSelectedStrokeWidth}
-                                    {...tab.props}
-                                    onPress={() => this.onTabPress(tab.id, index)}
-                                    selected={this._isSelected(tab.id)}
-                                />
-                            </View>
-                        ) : null
-                    )}
+                {this.props.tabs.map((tab, index) =>
+                    !tab.hidden ? (
+                        <View
+                            style={styles.buttonTab}
+                            key={tab.id}
+                            onLayout={event => this._onTabLayout(event, index)}
+                        >
+                            <ButtonTab
+                                text={tab.text}
+                                color={tab.color}
+                                colorSelected={tab.colorSelected}
+                                disabled={tab.disabled}
+                                fill={tab.fill}
+                                fillSelected={tab.fillSelected}
+                                badgeAnimationDuration={tab.badgeAnimationDuration}
+                                badgeBackgroundColor={tab.badgeBackgroundColor}
+                                badgeColor={tab.badgeColor}
+                                badgeCount={tab.badgeCount}
+                                badgeCountThreshold={tab.badgeCountThreshold}
+                                badgeHasAnimation={tab.badgeHasAnimation}
+                                badgeText={tab.badgeText}
+                                icon={tab.icon}
+                                iconSelected={tab.iconSelected}
+                                iconStrokeWidth={tab.iconStrokeWidth}
+                                iconSelectedStrokeWidth={tab.iconSelectedStrokeWidth}
+                                {...tab.props}
+                                onPress={() => this.onTabPress(tab.id, index)}
+                                selected={this._isSelected(tab.id)}
+                            />
+                        </View>
+                    ) : null
+                )}
             </SafeAreaView>
         );
     }

--- a/react/components/molecules/tabs/tabs.js
+++ b/react/components/molecules/tabs/tabs.js
@@ -131,7 +131,7 @@ export class Tabs extends PureComponent {
     };
 
     _style = () => {
-        return [styles.tabs, this.props.style, this._isHidden() ? { display: "none" } : {}];
+        return [styles.tabs, this.props.style];
     };
 
     _barAnimatedStyle = () => {
@@ -148,38 +148,39 @@ export class Tabs extends PureComponent {
                         width={this.state.animatedBarWidth}
                     />
                 ) : null}
-                {this.props.tabs.map((tab, index) =>
-                    !tab.hidden ? (
-                        <View
-                            style={styles.buttonTab}
-                            key={tab.id}
-                            onLayout={event => this._onTabLayout(event, index)}
-                        >
-                            <ButtonTab
-                                text={tab.text}
-                                color={tab.color}
-                                colorSelected={tab.colorSelected}
-                                disabled={tab.disabled}
-                                fill={tab.fill}
-                                fillSelected={tab.fillSelected}
-                                badgeAnimationDuration={tab.badgeAnimationDuration}
-                                badgeBackgroundColor={tab.badgeBackgroundColor}
-                                badgeColor={tab.badgeColor}
-                                badgeCount={tab.badgeCount}
-                                badgeCountThreshold={tab.badgeCountThreshold}
-                                badgeHasAnimation={tab.badgeHasAnimation}
-                                badgeText={tab.badgeText}
-                                icon={tab.icon}
-                                iconSelected={tab.iconSelected}
-                                iconStrokeWidth={tab.iconStrokeWidth}
-                                iconSelectedStrokeWidth={tab.iconSelectedStrokeWidth}
-                                {...tab.props}
-                                onPress={() => this.onTabPress(tab.id, index)}
-                                selected={this._isSelected(tab.id)}
-                            />
-                        </View>
-                    ) : null
-                )}
+                {!this._isHidden() &&
+                    this.props.tabs.map((tab, index) =>
+                        !tab.hidden ? (
+                            <View
+                                style={styles.buttonTab}
+                                key={tab.id}
+                                onLayout={event => this._onTabLayout(event, index)}
+                            >
+                                <ButtonTab
+                                    text={tab.text}
+                                    color={tab.color}
+                                    colorSelected={tab.colorSelected}
+                                    disabled={tab.disabled}
+                                    fill={tab.fill}
+                                    fillSelected={tab.fillSelected}
+                                    badgeAnimationDuration={tab.badgeAnimationDuration}
+                                    badgeBackgroundColor={tab.badgeBackgroundColor}
+                                    badgeColor={tab.badgeColor}
+                                    badgeCount={tab.badgeCount}
+                                    badgeCountThreshold={tab.badgeCountThreshold}
+                                    badgeHasAnimation={tab.badgeHasAnimation}
+                                    badgeText={tab.badgeText}
+                                    icon={tab.icon}
+                                    iconSelected={tab.iconSelected}
+                                    iconStrokeWidth={tab.iconStrokeWidth}
+                                    iconSelectedStrokeWidth={tab.iconSelectedStrokeWidth}
+                                    {...tab.props}
+                                    onPress={() => this.onTabPress(tab.id, index)}
+                                    selected={this._isSelected(tab.id)}
+                                />
+                            </View>
+                        ) : null
+                    )}
             </SafeAreaView>
         );
     }

--- a/react/components/molecules/tabs/tabs.js
+++ b/react/components/molecules/tabs/tabs.js
@@ -187,6 +187,7 @@ export class Tabs extends PureComponent {
 
 const styles = StyleSheet.create({
     tabs: {
+        paddingTop: 0,
         backgroundColor: "#ffffff",
         flexDirection: "row"
     },

--- a/react/components/molecules/tabs/tabs.js
+++ b/react/components/molecules/tabs/tabs.js
@@ -141,6 +141,13 @@ export class Tabs extends PureComponent {
     render() {
         return (
             <SafeAreaView style={this._style()}>
+                {this._animatedBarEnabled() ? (
+                    <BarAnimated
+                        style={this._barAnimatedStyle()}
+                        offset={this.state.animatedBarOffset}
+                        width={this.state.animatedBarWidth}
+                    />
+                ) : null}
                 {!this._isHidden() &&
                     this.props.tabs.map((tab, index) =>
                         !tab.hidden ? (
@@ -181,7 +188,6 @@ export class Tabs extends PureComponent {
 
 const styles = StyleSheet.create({
     tabs: {
-        paddingTop: 0,
         backgroundColor: "#ffffff",
         flexDirection: "row"
     },


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/472 |
| Decisions | - Bump `react-native-safe-area-context` version <br> - Use `SafeAreaView` from `react-native-safe-area-context` instead. <br> - Add always padding edge in the bottom as a prop `edges` of `SafeAreaView`. |

