### PR TITLE
#464 Fix spam and error SVG icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Fix tab visibility undesired extra padding - [ripe-robin-revamp/#472](https://github.com/ripe-tech/ripe-robin-revamp/issues/472])
+* Fix spam and error icons - [ripe-robin-revamp/#464](https://github.com/ripe-tech/ripe-robin-revamp/issues/464)
 
 ## [0.27.7] - 2022-10-21
 

--- a/react/assets/icons/error.svg
+++ b/react/assets/icons/error.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" aria-labelledby="errorIconTitle" stroke-linecap="square" fill="none"><path d="M12 8v5m0 3"/><circle cx="12" cy="12" r="10"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" aria-labelledby="spamIconTitle" stroke="#000" stroke-width="1.5" stroke-linecap="square" fill="none" color="#000"><path d="m16 3 5 5v8l-5 5H8l-5-5V8l5-5zm-4 5v5m0 3h0"/></svg>

--- a/react/assets/icons/error.svg
+++ b/react/assets/icons/error.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" aria-labelledby="errorIconTitle" stroke-width="1.5" stroke-linecap="square" fill="none"><path d="M12 8v5m0 3h0"/><circle cx="12" cy="12" r="10"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" aria-labelledby="errorIconTitle" stroke="none" stroke-width="1.5" stroke-linecap="square" fill="none" color="none"><path d="M12 8v5m0 3h0"/><circle cx="12" cy="12" r="10"/></svg>

--- a/react/assets/icons/error.svg
+++ b/react/assets/icons/error.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" aria-labelledby="errorIconTitle" stroke="none" stroke-width="1.5" stroke-linecap="square" fill="none" color="none"><path d="M12 8v5m0 3h0"/><circle cx="12" cy="12" r="10"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" aria-labelledby="errorIconTitle" stroke="#000" stroke-width="1.5" stroke-linecap="square" fill="none" color="#000"><path d="M12 8v5m0 3h0"/><circle cx="12" cy="12" r="10"/></svg>

--- a/react/assets/icons/error.svg
+++ b/react/assets/icons/error.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" aria-labelledby="spamIconTitle" stroke-width="1.5" stroke-linecap="square" fill="none"><path d="m16 3 5 5v8l-5 5H8l-5-5V8l5-5zm-4 5v5m0 3h0"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" aria-labelledby="errorIconTitle" stroke-width="1.5" stroke-linecap="square" fill="none"><path d="M12 8v5m0 3h0"/><circle cx="12" cy="12" r="10"/></svg>

--- a/react/assets/icons/error.svg
+++ b/react/assets/icons/error.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" aria-labelledby="spamIconTitle" stroke="#000" stroke-width="1.5" stroke-linecap="square" fill="none" color="#000"><path d="m16 3 5 5v8l-5 5H8l-5-5V8l5-5zm-4 5v5m0 3h0"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" aria-labelledby="spamIconTitle" stroke-width="1.5" stroke-linecap="square" fill="none"><path d="m16 3 5 5v8l-5 5H8l-5-5V8l5-5zm-4 5v5m0 3h0"/></svg>

--- a/react/assets/icons/spam.svg
+++ b/react/assets/icons/spam.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" aria-labelledby="spamIconTitle" stroke="none" stroke-width="1.5" stroke-linecap="square" fill="none" color="none"><path d="m16 3 5 5v8l-5 5H8l-5-5V8l5-5zm-4 5v5m0 3h0"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" aria-labelledby="spamIconTitle" stroke="#000" stroke-width="1.5" stroke-linecap="square" fill="none" color="#000"><path d="m16 3 5 5v8l-5 5H8l-5-5V8l5-5zm-4 5v5m0 3h0"/></svg>

--- a/react/assets/icons/spam.svg
+++ b/react/assets/icons/spam.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" aria-labelledby="spamIconTitle" stroke="#000" stroke-width="1.5" stroke-linecap="square" fill="none" color="#000"><path d="m16 3 5 5v8l-5 5H8l-5-5V8l5-5zm-4 5v5m0 3h0"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" aria-labelledby="spamIconTitle" stroke-width="1.5" stroke-linecap="square" fill="none"><path d="m16 3 5 5v8l-5 5H8l-5-5V8l5-5zm-4 5v5m0 3h0"/></svg>

--- a/react/assets/icons/spam.svg
+++ b/react/assets/icons/spam.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" aria-labelledby="spamIconTitle" stroke-width="1.5" stroke-linecap="square" fill="none"><path d="m16 3 5 5v8l-5 5H8l-5-5V8l5-5zm-4 5v5m0 3h0"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" aria-labelledby="spamIconTitle" stroke="none" stroke-width="1.5" stroke-linecap="square" fill="none" color="none"><path d="m16 3 5 5v8l-5 5H8l-5-5V8l5-5zm-4 5v5m0 3h0"/></svg>

--- a/react/assets/icons/spam.svg
+++ b/react/assets/icons/spam.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" aria-labelledby="spamIconTitle" stroke-width="1.5" stroke-linecap="square" fill="none"><path d="m16 3 5 5v8l-5 5H8l-5-5V8l5-5zm-4 5v5m0 3"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" aria-labelledby="spamIconTitle" stroke="#000" stroke-width="1.5" stroke-linecap="square" fill="none" color="#000"><path d="m16 3 5 5v8l-5 5H8l-5-5V8l5-5zm-4 5v5m0 3h0"/></svg>


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/464#issuecomment-1308983513 |
| Decisions | - Add color and stroke properties to the icons to overcome `pretty` running `svga` which simplifies the icon and removes the dots |
| Animated GIF | Please check in Github filechanges |
