### PR TITLE
#464 Fix send-alt icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fix tab visibility undesired extra padding - [ripe-robin-revamp/#472](https://github.com/ripe-tech/ripe-robin-revamp/issues/472])
 * Fix spam and error icons - [ripe-robin-revamp/#464](https://github.com/ripe-tech/ripe-robin-revamp/issues/464)
+* Fix send-alt icon viewport and size - [ripe-robin-revamp/#464](https://github.com/ripe-tech/ripe-robin-revamp/issues/464)
 
 ## [0.27.7] - 2022-10-21
 

--- a/react/assets/icons/extra/send-alt.svg
+++ b/react/assets/icons/extra/send-alt.svg
@@ -1,1 +1,1 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M14.412.923 1.244 5.06l3.495 3.485L9.56 5.804l-2.842 4.731 3.586 3.606L14.412.923Z" stroke="#4B8DD7"/></svg>
+<svg viewBox="0 0 24 24" width="48" height="48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="m20.282 3.779-16.551 5.2 4.394 4.381 6.059-3.446-3.573 5.947 4.507 4.532 5.164-16.614Z" stroke="#4B8DD7"/></svg>


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/464#issuecomment-1310493309 |
| Decisions | - Fix send-alt icon viewport and size |
| Animated GIF | Below |




| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/24736423/201166608-37e56c67-16c5-4117-9e44-207a02a05d9e.png) | ![image](https://user-images.githubusercontent.com/24736423/201166402-4a30f05c-c50d-48b9-9e9a-42b2262be308.png) |