### PR TITLE
chore: version 0.28.0 :rainbow: 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+*
+
+### Changed
+
+*
+
+### Fixed
+
+*
+
+## [0.28.0] - 2023-01-30
+
+### Added
+
 * Add pagination to `chat` by integrating the use of the `listing` component - [ripe-robin-revamp/#340](https://github.com/ripe-tech/ripe-robin-revamp/issues/340)
 * Add and adapt to newest chat message placeholder refresh component - [ripe-robin-revamp/#340](https://github.com/ripe-tech/ripe-robin-revamp/issues/340)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-components-react-native",
-    "version": "0.27.7",
+    "version": "0.28.0",
     "description": "RIPE Components for React Native",
     "keywords": [
         "components",


### PR DESCRIPTION

### Added

* Add pagination to `chat` by integrating the use of the `listing` component - [ripe-robin-revamp/#340](https://github.com/ripe-tech/ripe-robin-revamp/issues/340)
* Add and adapt to newest chat message placeholder refresh component - [ripe-robin-revamp/#340](https://github.com/ripe-tech/ripe-robin-revamp/issues/340)

### Changed
* Small style improvements to be consistent with the original design
* Small change in the alias used in listing filter components - [ripe-robin-revamp/#340](https://github.com/ripe-tech/ripe-robin-revamp/issues/340)
### Fixed
* Fix tab visibility undesired extra padding - [ripe-robin-revamp/#472](https://github.com/ripe-tech/ripe-robin-revamp/issues/472])
* Fix spam and error icons - [ripe-robin-revamp/#464](https://github.com/ripe-tech/ripe-robin-revamp/issues/464)
* Fix send-alt icon viewport and size - [ripe-robin-revamp/#464](https://github.com/ripe-tech/ripe-robin-revamp/issues/464)
* Fix no messages animation shadow - [ripe-robin-revamp/#489](https://github.com/ripe-tech/ripe-robin-revamp/issues/489)