### PR TITLE
Chat improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Add `attachButtonsVisibility` prop to allow hiding attach buttons
 
 ### Changed
 

--- a/react/components/molecules/rich-textinput/rich-textinput.js
+++ b/react/components/molecules/rich-textinput/rich-textinput.js
@@ -15,6 +15,7 @@ export class RichTextInput extends PureComponent {
             textareaMaxHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
             animationTime: PropTypes.number,
             sendButtonProps: PropTypes.object,
+            attachButtonsVisibility: PropTypes.bool,
             onPhotoAdded: PropTypes.func,
             onAttachmentsAdded: PropTypes.func,
             onSendMessage: PropTypes.func,
@@ -34,6 +35,7 @@ export class RichTextInput extends PureComponent {
             textareaMaxHeight: undefined,
             animationTime: 200,
             sendButtonProps: {},
+            attachButtonsVisibility: true,
             onPhotoAdded: image => {},
             onAttachmentsAdded: attachments => {},
             onSendMessage: text => {},
@@ -170,7 +172,13 @@ export class RichTextInput extends PureComponent {
     }
 
     _buttonsStyle() {
-        const style = [styles.buttons, { opacity: this.state.buttonsOpacityValue }];
+        const style = [
+            styles.buttons,
+            {
+                opacity: this.state.buttonsOpacityValue,
+                display: this.props.attachButtonsVisibility ? undefined : "none"
+            }
+        ];
 
         if (!this.state.buttonsVisible) style.push({ width: 0 });
         return style;
@@ -180,7 +188,8 @@ export class RichTextInput extends PureComponent {
         const style = [
             styles.moreOptions,
             {
-                opacity: this.state.moreOptionsOpacityValue
+                opacity: this.state.moreOptionsOpacityValue,
+                display: this.props.attachButtonsVisibility ? undefined : "none"
             }
         ];
 

--- a/react/components/organisms/chat/chat.js
+++ b/react/components/organisms/chat/chat.js
@@ -46,6 +46,7 @@ export class Chat extends PureComponent {
             noMessagesPlaceholder: PropTypes.string,
             imagePlaceholder: PropTypes.object,
             repliesTextColor: PropTypes.string,
+            attachButtonsVisibility: PropTypes.bool,
             onNewMessage: PropTypes.func,
             onScrollBottom: PropTypes.func,
             onScroll: PropTypes.func,
@@ -333,6 +334,7 @@ export class Chat extends PureComponent {
                     sendButtonProps={{ loading: this.state.sendingMessage }}
                     multiline={true}
                     textareaMaxHeight={baseStyles.FONT_SIZE * 5}
+                    attachButtonsVisibility={this.props.attachButtonsVisibility}
                     onPhotoAdded={image => this.onRichTextInputPhotoAdded(image)}
                     onAttachmentsAdded={attachments =>
                         this.onRichTextInputAttachmentsAdded(attachments)

--- a/react/components/organisms/chat/chat.js
+++ b/react/components/organisms/chat/chat.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from "react";
-import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, View } from "react-native";
 import { WebView } from "react-native-webview";
 import { Listing } from "ripe-components-react-native";
 import PropTypes from "prop-types";


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | - Add `attachButtonsVisibility` prop to allow hiding attach buttons.  |
| Animated GIF | Below |

### Before
![image](https://user-images.githubusercontent.com/24736423/215551630-89d686f1-03e3-47f0-852d-9b990da1e27d.png)
![image](https://user-images.githubusercontent.com/24736423/215551658-4a4fe8cb-91e1-4d99-ab5e-a7970369ffbe.png)

### After
![image](https://user-images.githubusercontent.com/24736423/215551828-6611cd81-938f-4ab9-abc3-3ae578da5479.png)
![image](https://user-images.githubusercontent.com/24736423/215551541-8f1bfe06-a3d5-4d68-adde-af94f3ca4b6e.png)

